### PR TITLE
Remove problematic print statement in catch block to prevent direct client response

### DIFF
--- a/Soneso/StellarSDK/Exceptions/HorizonRequestException.php
+++ b/Soneso/StellarSDK/Exceptions/HorizonRequestException.php
@@ -71,7 +71,7 @@ class HorizonRequestException extends \ErrorException
         }
 
         if ($e instanceof RequestException && $e->getResponse()) {
-            print($e->getResponse()->getBody()->__toString() . PHP_EOL);
+            // print($e->getResponse()->getBody()->__toString() . PHP_EOL);
             $httpResponse = $e->getResponse();
             $result->statusCode = $httpResponse->getStatusCode();
             $decoded = null;


### PR DESCRIPTION
This pull request removes a problematic `print` statement in a catch block that was causing the response to be sent directly to the client instead of being catchable. The print statement was triggering Laravel's response sending functionality and interfering with the error handling of the application.

#23 

#12 (maybe)