### PR TITLE
Fix: remove leading slash in RequestBuilder to respect base_uri path

### DIFF
--- a/Soneso/StellarSDK/Requests/RequestBuilder.php
+++ b/Soneso/StellarSDK/Requests/RequestBuilder.php
@@ -84,7 +84,7 @@ abstract class RequestBuilder
     
     public function buildUrl() : string {
         $implodedSegments = implode("/", $this->segments);
-        $result = "/" . $implodedSegments . "?" . http_build_query($this->queryParameters);
+        $result = $implodedSegments . "?" . http_build_query($this->queryParameters);
         //print($result . PHP_EOL);
         return $result;
     }


### PR DESCRIPTION
### Summary

This pull request fixes an issue where the SDK-generated request URLs would ignore any subpath defined in the `base_uri`.

### Problem

When using a Horizon endpoint that includes a subpath (e.g. `https://example.com/my_key/`), Guzzle's `base_uri` functionality should correctly prepend this path to all requests.

However, the current implementation in `RequestBuilder::buildUrl()` always prepends a leading slash (`/`), which causes Guzzle to treat the request path as **absolute** and override any custom path in `base_uri`.

For example:

```php
$client = new Client(['base_uri' => 'https://example.com/my_key/']);
$client->get('/accounts/XYZ'); // Results in https://example.com/accounts/XYZ — missing subpath!
```

### Solution

We removed the leading slash from the return value of buildUrl(), allowing Guzzle to properly append the relative path to base_uri.

New behavior:

```php
$client = new Client(['base_uri' => 'https://example.com/my_key/']);
$client->get('accounts/XYZ'); // Correct: https://example.com/my_key/accounts/XYZ
```

### Compatibility

This change is fully backward-compatible:

* For public Horizon servers (with no subpath), behavior remains exactly the same.
* For custom/private Horizon instances using subpaths, this enables proper support out-of-the-box.

### Notes

Tested against both public Horizon servers and custom endpoints with subpaths.

Let me know if you'd like any changes or additions!