### PR TITLE
Make ext-pcntl optional for Windows compatibility

### DIFF
--- a/Soneso/StellarSDKTests/Integration/AccountTest.php
+++ b/Soneso/StellarSDKTests/Integration/AccountTest.php
@@ -419,6 +419,10 @@ final class AccountTest extends TestCase
     }
 
     public function testStreamAccount(): void {
+        if (!function_exists('pcntl_fork')) {
+            $this->markTestSkipped('pcntl extension required for this test (Unix only).');
+        }
+
         // Create and fund test account
         $keyPair = KeyPair::random();
         $accountId = $keyPair->getAccountId();
@@ -503,6 +507,10 @@ final class AccountTest extends TestCase
     }
 
     public function testStreamAccountData(): void {
+        if (!function_exists('pcntl_fork')) {
+            $this->markTestSkipped('pcntl extension required for this test (Unix only).');
+        }
+
         // Create and fund test account
         $keyPair = KeyPair::random();
         $accountId = $keyPair->getAccountId();

--- a/Soneso/StellarSDKTests/Integration/QueryTest.php
+++ b/Soneso/StellarSDKTests/Integration/QueryTest.php
@@ -359,6 +359,9 @@ class QueryTest extends TestCase
 
 
     public function testStreamPayments():void {
+        if (!function_exists('pcntl_fork')) {
+            $this->markTestSkipped('pcntl extension required for this test (Unix only).');
+        }
 
         $keypair1 = KeyPair::random();
         $keypair2 = KeyPair::random();

--- a/composer.json
+++ b/composer.json
@@ -21,9 +21,11 @@
 		"phpseclib/phpseclib" : "^3.0",
 		"yosymfony/toml" : "~1.0",
       	"ext-bcmath": "*",
-		"ext-pcntl": "*",
 		"ext-gmp": "*"
     },
+	"suggest": {
+		"ext-pcntl": "Required for process forking in streaming integration tests (Unix only)"
+	},
 	"license" : "Apache-2.0",
 	"authors" : [{
 			"name" : "Christian Rogobete",

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -25,7 +25,7 @@ Install via Composer:
 composer require soneso/stellar-php-sdk
 ```
 
-**Requirements:** PHP 8.0+, ext-bcmath, ext-pcntl, ext-gmp
+**Requirements:** PHP 8.0+, ext-bcmath, ext-gmp. **Optional:** ext-pcntl (Unix only, used for process forking in integration tests).
 
 ## Basic Concepts
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -17,7 +17,7 @@ Install the SDK via Composer:
 composer require soneso/stellar-php-sdk
 ```
 
-**Requirements:** PHP 8.0 or higher (with `bcmath`, `gmp`, and `pcntl` extensions). See [Getting Started](getting-started.md) for full requirements.
+**Requirements:** PHP 8.0 or higher (with `bcmath` and `gmp` extensions). See [Getting Started](getting-started.md) for full requirements.
 
 ## Your First KeyPair
 


### PR DESCRIPTION
### Summary

See: #65. The SDK required `ext-pcntl` in `composer.json`, but pcntl is a Unix-only extension that made it harder for Windows developers to install the SDK via Composer. No SDK library code uses pcntl -- it is only used in integration tests for process forking.

### Changes

- Moved `ext-pcntl` from `require` to `suggest` in `composer.json`
- Added skip checks in integration tests that use `pcntl_fork()` if not available: (`QueryTest::testStreamPayments`, `AccountTest::testStreamAccount`, `AccountTest::testStreamAccountData`)
- Updated `docs/getting-started.md` and `docs/quick-start.md` to list pcntl as optional
- Added unit tests for the `CREATE_CONTRACT_V2` + `FROM_ASSET` deserialization path in `InvokeHostFunctionOperation`

### Test plan

- [x] Unit tests pass (2499 tests, 0 failures)
- [x] All `pcntl_fork()` call sites in tests are guarded with skip checks
- [x] SDK library code confirmed to have zero pcntl references
- [x] CI runs on Ubuntu where pcntl is available, so integration tests are unaffected