### PR TITLE
Remove redundant paragonie/sodium_compat dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
 		"php": ">=8.0",
 		"guzzlehttp/guzzle" : "^7.3",
 		"christian-riesen/base32" : "~1.6",
-		"paragonie/sodium_compat" : "^2.5.0",
 		"phpseclib/phpseclib" : "^3.0",
 		"psr/log": "^1.1 || ^2.0 || ^3.0",
 		"yosymfony/toml" : "~1.0",


### PR DESCRIPTION
This package depends on `paragonie/sodium_compat: ^2.5.0`, but also `php: >=8.0`. Since `libsodium` was added in PHP 7.2, the dependency on `paragonie/sodium_compat` seems redundant?