### PR TITLE
Replace paragonie/sodium_compat with native ext-sodium

### DIFF
--- a/.buildpath
+++ b/.buildpath
@@ -51,11 +51,6 @@
 			<attribute name="composer" value="vendor"/>
 		</attributes>
 	</buildpathentry>
-	<buildpathentry kind="src" path="vendor/paragonie/sodium_compat">
-		<attributes>
-			<attribute name="composer" value="vendor"/>
-		</attributes>
-	</buildpathentry>
 	<buildpathentry kind="src" path="vendor/phar-io/manifest/src">
 		<attributes>
 			<attribute name="composer" value="vendor"/>

--- a/Soneso/StellarSDK/Crypto/KeyPair.php
+++ b/Soneso/StellarSDK/Crypto/KeyPair.php
@@ -7,7 +7,6 @@
 namespace Soneso\StellarSDK\Crypto;
 
 use Exception;
-use ParagonIE\Sodium\Core\Ed25519;
 use SodiumException;
 use Soneso\StellarSDK\MuxedAccount;
 use Soneso\StellarSDK\SEP\Derivation\HDNode;
@@ -290,7 +289,7 @@ class KeyPair
     public function sign(string $value): string
     {
         try {
-            return Ed25519::sign_detached($value, $this->getEd25519SecretKey());
+            return sodium_crypto_sign_detached($value, $this->getEd25519SecretKey());
         } catch (SodiumException $e) {
             throw new CryptoException("Ed25519 signing failed", 0, $e);
         }
@@ -306,7 +305,7 @@ class KeyPair
     public function verifySignature(string $signature, string $message): bool
     {
         try {
-            return Ed25519::verify_detached($signature, $message, $this->publicKey);
+            return sodium_crypto_sign_verify_detached($signature, $message, $this->publicKey);
         } catch (SodiumException $e) {
             return false;
         }
@@ -462,9 +461,9 @@ class KeyPair
         }
 
         try {
-            $sk = '';
-            $pk = '';
-            Ed25519::seed_keypair($pk, $sk, $this->privateKey);
+            $keypair = sodium_crypto_sign_seed_keypair($this->privateKey);
+            $sk = substr($keypair, 0, SODIUM_CRYPTO_SIGN_SECRETKEYBYTES);
+            sodium_memzero($keypair);
         } catch (SodiumException $e) {
             throw new CryptoException("Ed25519 key derivation failed", 0, $e);
         }

--- a/Soneso/StellarSDK/Crypto/StrKey.php
+++ b/Soneso/StellarSDK/Crypto/StrKey.php
@@ -10,7 +10,7 @@ namespace Soneso\StellarSDK\Crypto;
 use Base32\Base32;
 use Exception;
 use InvalidArgumentException;
-use ParagonIE\Sodium\Core\Ed25519;
+use SodiumException;
 use Soneso\StellarSDK\Constants\CryptoConstants;
 use Soneso\StellarSDK\Constants\StellarConstants;
 use Soneso\StellarSDK\SignedPayloadSigner;
@@ -358,7 +358,14 @@ class StrKey
      * @throws \Exception If the private key is invalid or key derivation fails
      */
     public static function publicKeyFromPrivateKey($privateKey) {
-        return Ed25519::publickey_from_secretkey($privateKey);
+        try {
+            $keypair = sodium_crypto_sign_seed_keypair($privateKey);
+            $pk = substr($keypair, SODIUM_CRYPTO_SIGN_SECRETKEYBYTES, SODIUM_CRYPTO_SIGN_PUBLICKEYBYTES);
+            sodium_memzero($keypair);
+            return $pk;
+        } catch (SodiumException $e) {
+            throw new CryptoException("Ed25519 public key derivation failed", 0, $e);
+        }
     }
 
     /**

--- a/Soneso/StellarSDKTests/Unit/Crypto/PayloadSignerTest.php
+++ b/Soneso/StellarSDKTests/Unit/Crypto/PayloadSignerTest.php
@@ -3,7 +3,6 @@
 namespace Soneso\StellarSDKTests\Unit\Crypto;
 
 use DateTime;
-use ParagonIE\ConstantTime\Encoding;
 use phpseclib3\Math\BigInteger;
 use PHPUnit\Framework\TestCase;
 use Soneso\StellarSDK\Crypto\KeyPair;
@@ -61,7 +60,7 @@ class PayloadSignerTest extends TestCase
         // Valid signed payload with an ed25519 public key and a 32-byte payload.
         $accountStrKey = "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ";
         $p16 = "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20";
-        $payload = Encoding::hexDecode($p16);
+        $payload = hex2bin($p16);
         $xdrAccountID = new XdrAccountID($accountStrKey);
         $signedPayloadSigner = new SignedPayloadSigner($xdrAccountID, $payload);
         $encodedSignedPayload = StrKey::encodeSignedPayload($signedPayloadSigner);
@@ -69,7 +68,7 @@ class PayloadSignerTest extends TestCase
 
         // Valid signed payload with an ed25519 public key and a 29-byte payload.
         $p16 = "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d";
-        $payload = Encoding::hexDecode($p16);
+        $payload = hex2bin($p16);
         $xdrAccountID = new XdrAccountID($accountStrKey);
         $signedPayloadSigner = new SignedPayloadSigner($xdrAccountID, $payload);
         $encodedSignedPayload = StrKey::encodeSignedPayload($signedPayloadSigner);
@@ -87,7 +86,7 @@ class PayloadSignerTest extends TestCase
         $cond->setTimeBounds($tb);
         $accountStrKey = "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ";
         $payloadStr = "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20";
-        $payload = Encoding::hexDecode($payloadStr);
+        $payload = hex2bin($payloadStr);
         $signedPayloadSigner = new SignedPayloadSigner(new XdrAccountID($accountStrKey), $payload);
         $signedKey = Signer::signedPayload($signedPayloadSigner);
         $cond->setExtraSigners([$signedKey]);

--- a/Soneso/StellarSDKTests/Unit/Crypto/StrKeyTest.php
+++ b/Soneso/StellarSDKTests/Unit/Crypto/StrKeyTest.php
@@ -8,6 +8,7 @@ namespace Soneso\StellarSDKTests\Unit\Crypto;
 
 use Exception;
 use PHPUnit\Framework\TestCase;
+use Soneso\StellarSDK\Crypto\CryptoException;
 use Soneso\StellarSDK\Crypto\KeyPair;
 use Soneso\StellarSDK\Crypto\StrKey;
 use Soneso\StellarSDK\InvokeContractHostFunction;
@@ -431,6 +432,11 @@ class StrKeyTest extends TestCase
         $signature = $keyPair->sign($message);
         $verifyKeyPair = KeyPair::fromPublicKey($publicKey);
         assertTrue($verifyKeyPair->verifySignature($signature, $message));
+    }
+
+    public function testPublicKeyFromPrivateKeyInvalidInput() {
+        $this->expectException(CryptoException::class);
+        StrKey::publicKeyFromPrivateKey('invalid');
     }
 
     public function testXdrSignedPayloadEncodeDecode() {

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
 		"php": ">=8.0",
 		"guzzlehttp/guzzle" : "^7.3",
 		"christian-riesen/base32" : "~1.6",
-		"paragonie/sodium_compat" : "^2.5.0",
 		"phpseclib/phpseclib" : "^3.0",
 		"psr/log": "^1.1 || ^2.0 || ^3.0",
 		"yosymfony/toml" : "~1.0",
       	"ext-bcmath": "*",
-		"ext-gmp": "*"
+		"ext-gmp": "*",
+		"ext-sodium": "*"
     },
 	"suggest": {
 		"ext-pcntl": "Required for process forking in streaming integration tests (Unix only)"


### PR DESCRIPTION
Replace the `paragonie/sodium_compat` polyfill with PHP's native `ext-sodium` extension for all Ed25519 operations.

### Changes

- Migrate `KeyPair.php` and `StrKey.php` from `ParagonIE\Sodium\Core\Ed25519` to native `sodium_crypto_sign_*` functions
- Add `sodium_memzero()` calls in `KeyPair.php` and `StrKey.php` to clear intermediate key material after extraction
- Wrap `StrKey::publicKeyFromPrivateKey()` in proper error handling with `CryptoException`
- Add `ext-sodium` to composer.json requirements
- Remove `paragonie/sodium_compat` from composer.json
- Remove `paragonie/sodium_compat` entry from `.buildpath`
- Replace `ParagonIE\ConstantTime\Encoding::hexDecode()` with `hex2bin()` in `PayloadSignerTest.php`

### Why

All four Ed25519 calls have direct native equivalents available in every PHP version this SDK supports (>= 8.0). The native extension uses libsodium's C implementation, which is faster and has better side-channel resistance than the pure PHP polyfill.

Resolves #76
Ref: #75