### PR TITLE
SDK review improvements: fixes, hardening, performance and test coverage

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,0 +1,39 @@
+name: Dependency Audit
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: composer audit (production)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2.37.1
+        with:
+          php-version: '8.4'
+          extensions: mbstring, xml, ctype, json, bcmath, gmp, pcntl, sodium
+          coverage: none
+          tools: composer:v2
+
+      # composer.lock is intentionally gitignored (library), so dependencies are
+      # resolved fresh here; do not add --locked to the audit step.
+      - name: Install production dependencies
+        run: composer install --no-dev --prefer-dist --no-progress
+
+      # Fail only on security advisories in production dependencies; abandoned
+      # packages are reported but do not fail the build.
+      - name: Audit production dependencies
+        run: composer audit --no-dev --abandoned=report

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,0 +1,46 @@
+name: Static Analysis
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  phpstan:
+    name: PHPStan
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2.37.1
+        with:
+          php-version: '8.4'
+          extensions: mbstring, xml, ctype, json, bcmath, gmp, pcntl, sodium
+          coverage: none
+          tools: composer:v2
+
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress
+
+      - name: Run PHPStan
+        run: composer analyse

--- a/Soneso/StellarSDK/AbstractOperation.php
+++ b/Soneso/StellarSDK/AbstractOperation.php
@@ -103,7 +103,7 @@ abstract class AbstractOperation
         }
         $type = $body->getType()->getValue();
         $result = match ($type) {
-            XdrOperationType::CREATE_ACCOUNT => self::creatAccountOperation($body),
+            XdrOperationType::CREATE_ACCOUNT => self::createAccountOperation($body),
             XdrOperationType::PAYMENT => self::paymentOperation($body),
             XdrOperationType::PATH_PAYMENT_STRICT_RECEIVE => self::pathPaymentStrictReceiveOperation($body),
             XdrOperationType::MANAGE_SELL_OFFER => self::manageSellOfferOperation($body),
@@ -117,7 +117,7 @@ abstract class AbstractOperation
             XdrOperationType::MANAGE_BUY_OFFER => self::manageBuyOfferOperation($body),
             XdrOperationType::PATH_PAYMENT_STRICT_SEND => self::pathPaymentStrictSendOperation($body),
             XdrOperationType::CREATE_CLAIMABLE_BALANCE => self::createClaimableBalance($body),
-            XdrOperationType::CLAIM_CLAIMABLE_BALANCE => self::claimClaimableClaimableBalance($body),
+            XdrOperationType::CLAIM_CLAIMABLE_BALANCE => self::claimClaimableBalance($body),
             XdrOperationType::BEGIN_SPONSORING_FUTURE_RESERVES => self::beginSponsoringFutureReserves($body),
             XdrOperationType::END_SPONSORING_FUTURE_RESERVES => new EndSponsoringFutureReservesOperation(),
             XdrOperationType::REVOKE_SPONSORSHIP => self::revokeSponsorship($body),
@@ -140,7 +140,7 @@ abstract class AbstractOperation
         if ($op !== null) {
             return RestoreFootprintOperation::fromXdrOperation($op);
         } else {
-            throw new InvalidArgumentException("missing invoke host function operation in xdr operation body");
+            throw new InvalidArgumentException("missing restore footprint operation in xdr operation body");
         }
     }
 
@@ -149,7 +149,7 @@ abstract class AbstractOperation
         if ($op !== null) {
             return ExtendFootprintTTLOperation::fromXdrOperation($op);
         } else {
-            throw new InvalidArgumentException("missing invoke host function operation in xdr operation body");
+            throw new InvalidArgumentException("missing extend footprint TTL operation in xdr operation body");
         }
     }
 
@@ -225,7 +225,7 @@ abstract class AbstractOperation
         }
     }
 
-    private static function claimClaimableClaimableBalance(XdrOperationBody $body) : ClaimClaimableBalanceOperation {
+    private static function claimClaimableBalance(XdrOperationBody $body) : ClaimClaimableBalanceOperation {
         $op = $body->getClaimClaimableBalanceOperation();
         if ($op !== null) {
             return ClaimClaimableBalanceOperation::fromXdrOperation($op);
@@ -288,7 +288,7 @@ abstract class AbstractOperation
         }
     }
 
-    private static function creatAccountOperation(XdrOperationBody $body) : CreateAccountOperation {
+    private static function createAccountOperation(XdrOperationBody $body) : CreateAccountOperation {
         $caOp = $body->getCreateAccountOp();
         if ($caOp !== null) {
             return CreateAccountOperation::fromXdrOperation($caOp);

--- a/Soneso/StellarSDK/Asset.php
+++ b/Soneso/StellarSDK/Asset.php
@@ -47,7 +47,7 @@ abstract class Asset {
     public const TYPE_NATIVE = "native";
     public const TYPE_CREDIT_ALPHANUM_4 = "credit_alphanum4";
     public const TYPE_CREDIT_ALPHANUM_12 = "credit_alphanum12";
-    public const TYPE_POOL_SHARE = "liquidty_pool_shares";
+    public const TYPE_POOL_SHARE = "liquidity_pool_shares";
 
     /**
      * Returns the type of this asset
@@ -59,11 +59,15 @@ abstract class Asset {
     /**
      * Creates an asset from its type, code, and issuer
      *
-     * @param string $type One of the TYPE_* constants
+     * Pool share assets cannot be created here because they are composed of two
+     * assets rather than a code and issuer; construct an AssetTypePoolShare directly.
+     *
+     * @param string $type TYPE_NATIVE, TYPE_CREDIT_ALPHANUM_4 or TYPE_CREDIT_ALPHANUM_12
      * @param string|null $code Asset code (required for non-native assets)
      * @param string|null $issuer Issuer account ID (required for non-native assets)
      * @return Asset The created asset
      * @throws \RuntimeException If parameters are invalid or type is unsupported
+     * @see AssetTypePoolShare For liquidity pool share assets
      */
     public static function create(string $type, ?string $code = null, ?string $issuer = null) : Asset {
         if (Asset::TYPE_NATIVE == $type) {
@@ -79,6 +83,10 @@ abstract class Asset {
 
             return Asset::createNonNativeAsset($code, $issuer);
 
+        }
+        if (Asset::TYPE_POOL_SHARE == $type) {
+            throw new \RuntimeException(
+                "pool share assets are composed of two assets and can not be created from a code and issuer; construct AssetTypePoolShare directly");
         }
         throw new \RuntimeException("unsupported asset type: " . $type);
     }

--- a/Soneso/StellarSDK/Crypto/KeyPair.php
+++ b/Soneso/StellarSDK/Crypto/KeyPair.php
@@ -7,7 +7,9 @@
 namespace Soneso\StellarSDK\Crypto;
 
 use Exception;
+use InvalidArgumentException;
 use SodiumException;
+use Soneso\StellarSDK\Constants\StellarConstants;
 use Soneso\StellarSDK\MuxedAccount;
 use Soneso\StellarSDK\SEP\Derivation\HDNode;
 use Soneso\StellarSDK\SEP\Derivation\Mnemonic;
@@ -88,9 +90,18 @@ class KeyPair
      *
      * @param string $publicKey Raw 32-byte Ed25519 public key
      * @param string|null $privateKey Optional raw 32-byte Ed25519 private key (seed)
+     * @throws InvalidArgumentException If a key does not consist of exactly 32 bytes
      */
     public function __construct(string $publicKey, ?string $privateKey = null)
     {
+        if (strlen($publicKey) !== StellarConstants::ED25519_PUBLIC_KEY_LENGTH_BYTES) {
+            throw new InvalidArgumentException(
+                'Public key must be 32 bytes, got ' . strlen($publicKey));
+        }
+        if ($privateKey && strlen($privateKey) !== StellarConstants::ED25519_PUBLIC_KEY_LENGTH_BYTES) {
+            throw new InvalidArgumentException(
+                'Private key must be 32 bytes, got ' . strlen($privateKey));
+        }
         $this->publicKey = $publicKey;
         $this->accountId = StrKey::encodeAccountId($publicKey);
         if ($privateKey) {
@@ -153,8 +164,13 @@ class KeyPair
      *
      * @param string $privateKey Raw 32-byte Ed25519 private key seed
      * @return KeyPair A complete keypair derived from the private key
+     * @throws InvalidArgumentException If the private key does not consist of exactly 32 bytes
      */
     public static function fromPrivateKey(string $privateKey): KeyPair{
+        if (strlen($privateKey) !== StellarConstants::ED25519_PUBLIC_KEY_LENGTH_BYTES) {
+            throw new InvalidArgumentException(
+                'Private key must be 32 bytes, got ' . strlen($privateKey));
+        }
         return new KeyPair(StrKey::publicKeyFromPrivateKey($privateKey), $privateKey);
     }
 

--- a/Soneso/StellarSDK/Crypto/KeyPair.php
+++ b/Soneso/StellarSDK/Crypto/KeyPair.php
@@ -242,20 +242,19 @@ class KeyPair
     public function signPayloadDecorated(string $signerPayload): XdrDecoratedSignature
     {
         $payloadSignature = $this->signDecorated($signerPayload);
-        $payloadSignatureHint = str_split($payloadSignature->getHint());
-        $hintArr = str_split($signerPayload,1);
-        $lenBytes = count($hintArr);
-        if ($lenBytes >= 4) {
-            $hintArr = array_slice($hintArr, $lenBytes - 4,4);
-        } else {
-            while (count($hintArr) < 4) {
-                $hintArr[] = 0;
-            }
+        $keyHint = $payloadSignature->getHint();
+        // Take the last 4 bytes of the payload, right-padding with zeros when the
+        // payload is shorter than the 4-byte hint, then XOR byte-for-byte with the
+        // key hint (CAP-40). Padded positions keep the key-hint byte.
+        $len = strlen($signerPayload);
+        $payloadHint = $len >= 4
+            ? substr($signerPayload, $len - 4, 4)
+            : $signerPayload . str_repeat("\x00", 4 - $len);
+        $hint = '';
+        for ($x = 0; $x < 4; $x++) {
+            $hint .= chr(ord($payloadHint[$x]) ^ ord($keyHint[$x]));
         }
-        for ($x = 0; $x < count($hintArr); $x++) {
-            $hintArr[$x] ^= $payloadSignatureHint[$x];
-        }
-        $payloadSignature->setHint(implode($hintArr));
+        $payloadSignature->setHint($hint);
         return $payloadSignature;
     }
 

--- a/Soneso/StellarSDK/Memo.php
+++ b/Soneso/StellarSDK/Memo.php
@@ -8,6 +8,7 @@
 namespace Soneso\StellarSDK;
 
 use InvalidArgumentException;
+use phpseclib3\Math\BigInteger;
 use Soneso\StellarSDK\Constants\StellarConstants;
 use Soneso\StellarSDK\Xdr\XdrMemo;
 use Soneso\StellarSDK\Xdr\XdrMemoType;
@@ -22,7 +23,7 @@ use Soneso\StellarSDK\Xdr\XdrMemoType;
  * Supported memo types:
  * - NONE: No memo (default)
  * - TEXT: UTF-8 text string up to 28 bytes
- * - ID: Unsigned 64-bit integer
+ * - ID: Unsigned 64-bit integer (values above PHP_INT_MAX are represented as decimal strings)
  * - HASH: 32-byte hash (e.g., for hash preimages)
  * - RETURN: 32-byte hash for return payments
  *
@@ -36,6 +37,9 @@ class Memo
     const MEMO_TYPE_ID = 2;
     const MEMO_TYPE_HASH = 3;
     const MEMO_TYPE_RETURN = 4;
+
+    private const UINT64_MAX = '18446744073709551615';
+    private const UINT64_MODULUS = '18446744073709551616';
 
     /**
      * See the MEMO_TYPE constants
@@ -73,11 +77,27 @@ class Memo
     /**
      * Gets the memo value
      *
+     * For id memos the value is an int, or an unsigned decimal string when the
+     * id is above PHP_INT_MAX. Use getIdAsString() for a uniform representation.
+     *
      * @return mixed The memo value (type depends on memo type)
      */
     public function getValue(): mixed
     {
         return $this->value;
+    }
+
+    /**
+     * Gets the id memo value as an unsigned decimal string
+     *
+     * @return string|null The id as a decimal string, or null if this memo is not of type ID
+     */
+    public function getIdAsString(): ?string
+    {
+        if ($this->type != static::MEMO_TYPE_ID || $this->value === null) {
+            return null;
+        }
+        return strval($this->value);
     }
 
     /**
@@ -103,11 +123,14 @@ class Memo
     /**
      * Creates an ID memo
      *
-     * @param int $id The unsigned 64-bit integer value
+     * The id is an unsigned 64-bit integer. Values above PHP_INT_MAX must be
+     * passed as a decimal string.
+     *
+     * @param int|string $id The id as a non-negative int or unsigned decimal string
      * @return Memo A memo of type ID
-     * @throws InvalidArgumentException If ID is negative or exceeds maximum
+     * @throws InvalidArgumentException If the id is negative, not a decimal string, or exceeds 2^64-1
      */
-    public static function id(int $id) : Memo {
+    public static function id(int|string $id) : Memo {
         return new Memo(self::MEMO_TYPE_ID, $id);
     }
 
@@ -149,8 +172,20 @@ class Memo
             }
         }
         if ($this->type == static::MEMO_TYPE_ID) {
-            if ($this->value < 0) throw new InvalidArgumentException('value cannot be negative');
-            if ($this->value > PHP_INT_MAX) throw new InvalidArgumentException(sprintf('value cannot be larger than %s', PHP_INT_MAX));
+            // The id is an unsigned 64-bit integer: a non-negative int, or an
+            // unsigned decimal string for values above PHP_INT_MAX.
+            if (is_int($this->value)) {
+                if ($this->value < 0) throw new InvalidArgumentException('value cannot be negative');
+            } else if (is_string($this->value)) {
+                if (!preg_match('/\A(0|[1-9][0-9]*)\z/', $this->value)) {
+                    throw new InvalidArgumentException('id memo value must be an unsigned decimal integer');
+                }
+                if ((new BigInteger($this->value))->compare(new BigInteger(self::UINT64_MAX)) > 0) {
+                    throw new InvalidArgumentException(sprintf('value cannot be larger than %s', self::UINT64_MAX));
+                }
+            } else {
+                throw new InvalidArgumentException('id memo value must be an int or an unsigned decimal string');
+            }
         }
         if ($this->type == static::MEMO_TYPE_HASH || $this->type == static::MEMO_TYPE_RETURN) {
             if (strlen($this->value) !== StellarConstants::MEMO_HASH_LENGTH) throw new InvalidArgumentException(sprintf('hash values must be %s bytes, got %s bytes', StellarConstants::MEMO_HASH_LENGTH, strlen($this->value)));
@@ -180,8 +215,8 @@ class Memo
      *
      * @return string|null the value of this memo as a string if any. If the memo type is 'return' or 'hash' it
      * returns a base 64 encoded string of the memo value. If the memo type is 'text' it just returns the value.
-     * If the memo type is 'id' it returns the string representation of the int value. If the memo typ is 'none',
-     * it returns null.
+     * If the memo type is 'id' it returns the unsigned decimal string representation of the id. If the memo type
+     * is 'none', it returns null.
      */
     public function valueAsString(): ?string
     {
@@ -220,7 +255,7 @@ class Memo
                 $xdr->setHash($this->getValue());
                 break;
             case static::MEMO_TYPE_ID:
-                $xdr->setId($this->getValue());
+                $xdr->setId(self::idValueToXdrInt($this->value));
                 break;
             case static::MEMO_TYPE_RETURN:
                 $xdr->setReturnHash($this->getValue());
@@ -244,7 +279,10 @@ class Memo
             $value = $xdr->getText();
         }
         else if ($type == static::MEMO_TYPE_ID) {
-            $value = $xdr->getId();
+            // Ids above PHP_INT_MAX decode as negative ints; expose them as
+            // unsigned decimal strings instead.
+            $raw = $xdr->getId();
+            $value = $raw < 0 ? sprintf('%u', $raw) : $raw;
         }
         else if ($type == static::MEMO_TYPE_HASH) {
             $value = $xdr->getHash();
@@ -252,5 +290,23 @@ class Memo
             $value = $xdr->getReturnHash();
         }
         return new Memo($type, $value);
+    }
+
+    /**
+     * Converts an id memo value to the raw 64-bit integer used by XDR.
+     *
+     * Decimal strings above PHP_INT_MAX wrap to their two's complement int
+     * representation, which encodes to the correct unsigned bytes.
+     */
+    private static function idValueToXdrInt(int|string $value): int
+    {
+        if (is_int($value)) {
+            return $value;
+        }
+        $big = new BigInteger($value);
+        if ($big->compare(new BigInteger(strval(PHP_INT_MAX))) > 0) {
+            $big = $big->subtract(new BigInteger(self::UINT64_MODULUS));
+        }
+        return (int)$big->toString();
     }
 }

--- a/Soneso/StellarSDK/Requests/RequestBuilder.php
+++ b/Soneso/StellarSDK/Requests/RequestBuilder.php
@@ -201,35 +201,23 @@ abstract class RequestBuilder
                 ]);
 
                 $body = $response->getBody();
+                $buffer = '';
 
                 while (!$body->eof()) {
-                    $line = '';
-
-                    $char = null;
-                    while ($char != "\n") {
-                        $line .= $char;
-                        $char = $body->read(1);
+                    $chunk = $body->read(8192);
+                    // An empty read means the stream has been closed; reconnect.
+                    if ($chunk === '') {
+                        break;
                     }
+                    $buffer .= $chunk;
 
-                    // Ignore empty lines
-                    if (!$line) continue;
-
-                    // Ignore "data: hello" handshake
-                    if (str_starts_with($line, 'data: "hello"')) continue;
-
-                    // "data: byebye" if closed, restart
-                    if (str_starts_with($line, 'data: "byebye"')) break;
-
-                    // Ignore lines that don't start with "data: "
-                    $sentinel = 'data: ';
-                    if (!str_starts_with($line, $sentinel)) continue;
-
-                    // Remove sentinel prefix
-                    $json = substr($line, strlen($sentinel));
-
-                    $decoded = json_decode($json, true);
-                    if ($decoded) {
-                        $callback($decoded);
+                    $result = self::consumeStreamEvents($buffer);
+                    foreach ($result['events'] as $event) {
+                        $callback($event);
+                    }
+                    // A "data: byebye" line was received; restart the connection.
+                    if ($result['stop']) {
+                        break;
                     }
                 }
             }
@@ -240,5 +228,49 @@ abstract class RequestBuilder
                 sleep(10);
             }
         }
+    }
+
+    /**
+     * Consumes complete, newline-terminated SSE lines from the buffer and
+     * returns the decoded "data:" events to dispatch.
+     *
+     * Complete lines are removed from $buffer; any trailing partial line (not
+     * yet terminated by a newline) is left in place so it can be completed by
+     * the next read. Empty lines, the "hello" handshake, and non-"data:" lines
+     * are ignored. A "byebye" line stops consumption and sets the stop flag,
+     * signalling the caller to reconnect.
+     *
+     * @param string $buffer Accumulated stream bytes; mutated in place.
+     * @return array{events: array<int, mixed>, stop: bool}
+     */
+    private static function consumeStreamEvents(string &$buffer): array
+    {
+        $events = [];
+        $sentinel = 'data: ';
+        while (($pos = strpos($buffer, "\n")) !== false) {
+            $line = substr($buffer, 0, $pos);
+            $buffer = substr($buffer, $pos + 1);
+
+            // Ignore empty lines
+            if ($line === '') continue;
+
+            // Ignore "data: hello" handshake
+            if (str_starts_with($line, 'data: "hello"')) continue;
+
+            // "data: byebye" if closed, restart
+            if (str_starts_with($line, 'data: "byebye"')) {
+                return ['events' => $events, 'stop' => true];
+            }
+
+            // Ignore lines that don't start with "data: "
+            if (!str_starts_with($line, $sentinel)) continue;
+
+            // Remove sentinel prefix and decode
+            $decoded = json_decode(substr($line, strlen($sentinel)), true);
+            if ($decoded) {
+                $events[] = $decoded;
+            }
+        }
+        return ['events' => $events, 'stop' => false];
     }
 }

--- a/Soneso/StellarSDK/Responses/Effects/LiquidityPoolEffectResponse.php
+++ b/Soneso/StellarSDK/Responses/Effects/LiquidityPoolEffectResponse.php
@@ -24,7 +24,7 @@ use Soneso\StellarSDK\Responses\LiquidityPools\ReservesResponse;
 class LiquidityPoolEffectResponse extends EffectResponse
 {
     private string $poolId;
-    private int $fee; // TODO: Bigint
+    private int $fee; // fee in basis points (fee_bp), int32 on chain
     private string $type;
     private string $totalTrustlines;
     private string $totalShares;

--- a/Soneso/StellarSDK/Responses/LiquidityPools/LiquidityPoolResponse.php
+++ b/Soneso/StellarSDK/Responses/LiquidityPools/LiquidityPoolResponse.php
@@ -42,7 +42,7 @@ class LiquidityPoolResponse extends Response
 {
     private string $poolId;
     private string $pagingToken;
-    private int $fee; // TODO: Bigint
+    private int $fee; // fee in basis points (fee_bp), int32 on chain
     private string $type;
     private string $totalTrustlines;
     private string $totalShares;

--- a/Soneso/StellarSDK/SEP/CrossBorderPayments/CrossBorderPaymentsService.php
+++ b/Soneso/StellarSDK/SEP/CrossBorderPayments/CrossBorderPaymentsService.php
@@ -142,7 +142,7 @@ class CrossBorderPaymentsService
                     }
                     throw new SEP31CustomerInfoNeededException(type: $type);
                 } else if ($errorMsg === 'transaction_info_needed') {
-                    throw new SEP31TransactionInfoNeededException(fields: $jsonData['fields']);
+                    throw new SEP31TransactionInfoNeededException(fields: $jsonData['fields'] ?? null);
                 }
                 throw new SEP31BadRequestException($errorMsg, $statusCode);
             } else {

--- a/Soneso/StellarSDK/SEP/Federation/Federation.php
+++ b/Soneso/StellarSDK/SEP/Federation/Federation.php
@@ -44,7 +44,7 @@ class Federation {
 
         $array = explode("*",$address);
         $domain = $array[count($array) - 1];
-        $stellarToml = StellarToml::fromDomain($domain);
+        $stellarToml = StellarToml::fromDomain($domain, $httpClient);
         $federationServerUrl = $stellarToml->getGeneralInformation()->federationServer;
 
         if (!$federationServerUrl) {

--- a/Soneso/StellarSDK/SEP/Toml/StellarToml.php
+++ b/Soneso/StellarSDK/SEP/Toml/StellarToml.php
@@ -254,12 +254,15 @@ class StellarToml
      * as the currency's only field. This method loads the currency data from that URL.
      *
      * @param string $toml The URL to the currency TOML file
+     * @param Client|null $httpClient Optional HTTP client to use for the request. Default is Guzzle.
      * @return Currency The parsed currency data
      * @throws Exception If the currency TOML file cannot be fetched or parsed
      */
-    public static function currencyFromUrl(string $toml) : Currency {
+    public static function currencyFromUrl(string $toml, ?Client $httpClient = null) : Currency {
         UrlValidator::validateHttpsRequired($toml);
-        $httpClient = new Client();
+        if ($httpClient === null) {
+            $httpClient = new Client();
+        }
         try {
             $request = new Request('GET', $toml, RequestBuilder::HEADERS);
             $response = $httpClient->send($request);

--- a/Soneso/StellarSDK/SEP/URIScheme/URIScheme.php
+++ b/Soneso/StellarSDK/SEP/URIScheme/URIScheme.php
@@ -450,11 +450,13 @@ class URIScheme
      * @return bool True if signature is valid, false otherwise
      */
     private function verify(string $url, string $urlEncodedBase64Signature, KeyPair $signerPublicKey) : bool {
-        $sigParam = '&'.URIScheme::signatureParameterName.'='.$urlEncodedBase64Signature;
-        $pos = strrpos($url, $sigParam);
-        $urlSignatureLess = ($pos !== false)
-            ? substr_replace($url, '', $pos, strlen($sigParam))
-            : $url;
+        // The signature is the trailing parameter (SEP-7), so the signed payload
+        // is everything before "&signature=". Stripping by the marker rather than
+        // by the exact encoded value makes verification independent of how the
+        // signature was URL-encoded.
+        $sigMarker = '&'.URIScheme::signatureParameterName.'=';
+        $pos = strpos($url, $sigMarker);
+        $urlSignatureLess = ($pos !== false) ? substr($url, 0, $pos) : $url;
         $payloadBytes = $this->getPayload($urlSignatureLess);
         $base64Signature = urldecode($urlEncodedBase64Signature);
         $signature = base64_decode($base64Signature, true);

--- a/Soneso/StellarSDK/SEP/WebAuth/WebAuth.php
+++ b/Soneso/StellarSDK/SEP/WebAuth/WebAuth.php
@@ -431,7 +431,7 @@ class WebAuth
             }
 
             if ($count == 0 && $dataName != ($this->serverHomeDomain . " auth")) {
-                throw new ChallengeValidationErrorInvalidHomeDomain("invalid source account in operation[".$count."]");
+                throw new ChallengeValidationErrorInvalidHomeDomain("invalid home domain in operation[".$count."]");
             }
 
             $dataValue = $operation->getBody()->getManageDataOperation()->getValue();
@@ -443,39 +443,53 @@ class WebAuth
                 }
             }
 
-            // check timebounds
-            $timeBounds = $transaction->getTimeBounds();
-            if ($timeBounds) {
-                $grace = 0;
-                if ($timeBoundsGracePeriod) {
-                    $grace = $timeBoundsGracePeriod;
-                }
-                $currentTime = round(microtime(true));
-                if ($currentTime < $timeBounds->getMinTimestamp() - $grace ||
-                    $currentTime > $timeBounds->getMaxTimestamp() + $grace) {
-                    throw new ChallengeValidationErrorInvalidTimeBounds(
-                        "Invalid transaction, invalid time bounds");
-                }
-            }
-
-            // the envelope must have one signature and it must be valid: transaction signed by the server
-            $signatures = $envelopeXdr->getV1()->getSignatures();
-            if (count($signatures) != 1) {
-                throw new ChallengeValidationErrorInvalidSignature("Invalid transaction envelope, invalid number of signatures");
-            }
-            $firstSignature = $signatures[0];
-
-            if (!$firstSignature instanceof XdrDecoratedSignature) {
-                throw new ChallengeValidationErrorInvalidSignature("Invalid transaction envelope, invalid signature type");
-            }
-            // validate signature
-            $serverKeyPair = KeyPair::fromAccountId($this->serverSigningKey);
-            $transactionHash = (AbstractTransaction::fromEnvelopeXdr($envelopeXdr))->hash($this->network);
-            $valid = $serverKeyPair->verifySignature($firstSignature->getSignature(), $transactionHash);
-            if (!$valid) {
-                throw new ChallengeValidationErrorInvalidSignature("Invalid transaction envelope, invalid signature");
-            }
             $count += 1;
+        }
+
+        // Time bounds are a transaction-level property and are validated once,
+        // after the per-operation checks. SEP-10 requires the challenge to carry
+        // time bounds, so their absence is rejected (an unbounded challenge could
+        // otherwise be replayed indefinitely).
+        $timeBounds = $transaction->getTimeBounds();
+        if ($timeBounds === null) {
+            throw new ChallengeValidationErrorInvalidTimeBounds(
+                "Invalid transaction, missing time bounds");
+        }
+        // A maximum timestamp of 0 means unbounded, which would keep the
+        // challenge valid forever and defeat replay protection.
+        if ($timeBounds->getMaxTimestamp() == 0) {
+            throw new ChallengeValidationErrorInvalidTimeBounds(
+                "Invalid transaction, requires non-infinite time bounds");
+        }
+        $grace = 0;
+        if ($timeBoundsGracePeriod) {
+            $grace = $timeBoundsGracePeriod;
+        }
+        $currentTime = round(microtime(true));
+        if ($currentTime < $timeBounds->getMinTimestamp() - $grace ||
+            $currentTime > $timeBounds->getMaxTimestamp() + $grace) {
+            throw new ChallengeValidationErrorInvalidTimeBounds(
+                "Invalid transaction, invalid time bounds");
+        }
+
+        // The envelope is signed at the transaction level, so its signature is
+        // verified once: it must carry exactly one signature, produced by the
+        // server signing key over the transaction hash.
+        $signatures = $envelopeXdr->getV1()->getSignatures();
+        if (count($signatures) != 1) {
+            throw new ChallengeValidationErrorInvalidSignature("Invalid transaction envelope, invalid number of signatures");
+        }
+        $firstSignature = $signatures[0];
+
+        if (!$firstSignature instanceof XdrDecoratedSignature) {
+            throw new ChallengeValidationErrorInvalidSignature("Invalid transaction envelope, invalid signature type");
+        }
+        // validate signature
+        $serverKeyPair = KeyPair::fromAccountId($this->serverSigningKey);
+        $transactionHash = (AbstractTransaction::fromEnvelopeXdr($envelopeXdr))->hash($this->network);
+        $valid = $serverKeyPair->verifySignature($firstSignature->getSignature(), $transactionHash);
+        if (!$valid) {
+            throw new ChallengeValidationErrorInvalidSignature("Invalid transaction envelope, invalid signature");
         }
     }
 

--- a/Soneso/StellarSDK/Soroban/Contract/AssembledTransaction.php
+++ b/Soneso/StellarSDK/Soroban/Contract/AssembledTransaction.php
@@ -733,8 +733,9 @@ class AssembledTransaction
     /**
      * Polls the transaction status until it reaches a terminal state
      *
-     * Repeatedly queries getTransaction until the transaction is found or the configured
-     * timeout is exceeded. Uses a 3-second delay between polls.
+     * Queries getTransaction immediately, then retries with exponential backoff
+     * (1 second initial delay, factor 1.5) until the transaction is found or the
+     * configured timeout is exceeded.
      *
      * @internal This is an internal helper method used by send()
      *
@@ -744,21 +745,22 @@ class AssembledTransaction
      * @throws Exception If the timeout is exceeded before the transaction completes
      */
     private function pollStatus(string $transactionId) : GetTransactionResponse {
-        $statusResponse = null;
-        $status = GetTransactionResponse::STATUS_NOT_FOUND;
-        $waitTime = 3;
-        $waited = 0;
-        while ($status === GetTransactionResponse::STATUS_NOT_FOUND) {
-            if ($waited > $this->options->methodOptions->timeoutInSeconds) {
-                throw new Exception("Interrupted after waiting {$this->options->methodOptions->timeoutInSeconds} 
+        $deadline = microtime(true) + $this->options->methodOptions->timeoutInSeconds;
+        $waitTimeSeconds = 1.0;
+        while (true) {
+            $statusResponse = $this->server->getTransaction($transactionId);
+            if ($statusResponse->status !== GetTransactionResponse::STATUS_NOT_FOUND) {
+                return $statusResponse;
+            }
+            $remainingSeconds = $deadline - microtime(true);
+            if ($remainingSeconds <= 0) {
+                throw new Exception("Interrupted after waiting {$this->options->methodOptions->timeoutInSeconds}
                 seconds (options->timeoutInSeconds) for the transaction {$transactionId} to complete.");
             }
-            sleep($waitTime);
-            $waited += $waitTime;
-            $statusResponse = $this->server->getTransaction($transactionId);
-            $status = $statusResponse->status;
+            // Never sleep past the deadline.
+            usleep((int)(min($waitTimeSeconds, $remainingSeconds) * 1000000));
+            $waitTimeSeconds *= 1.5;
         }
-        return $statusResponse;
     }
     /**
      * Fetches the source account from the ledger

--- a/Soneso/StellarSDK/Soroban/Contract/AssembledTransaction.php
+++ b/Soneso/StellarSDK/Soroban/Contract/AssembledTransaction.php
@@ -272,7 +272,8 @@ class AssembledTransaction
     private function __construct(AssembledTransactionOptions $options)
     {
         $this->options= $options;
-        $this->server = new SorobanServer(endpoint: $options->clientOptions->rpcUrl);
+        $this->server = $options->clientOptions->server
+            ?? new SorobanServer(endpoint: $options->clientOptions->rpcUrl);
         if ($options->logger !== null) {
             $this->server->setLogger($options->logger);
         }

--- a/Soneso/StellarSDK/Soroban/Contract/ClientOptions.php
+++ b/Soneso/StellarSDK/Soroban/Contract/ClientOptions.php
@@ -9,6 +9,7 @@ namespace Soneso\StellarSDK\Soroban\Contract;
 use Psr\Log\LoggerInterface;
 use Soneso\StellarSDK\Crypto\KeyPair;
 use Soneso\StellarSDK\Network;
+use Soneso\StellarSDK\Soroban\SorobanServer;
 
 /**
  * Client configuration options for Soroban smart contract interactions
@@ -32,6 +33,9 @@ class ClientOptions
      * @param Network $network The Stellar network this contract is deployed to.
      * @param string $rpcUrl The URL of the RPC instance that will be used to interact with this contract.
      * @param LoggerInterface|null $logger PSR-3 logger for debug output. Default: null (no logging).
+     * @param SorobanServer|null $server RPC server instance to use. When null, one is created
+     *                                   automatically from $rpcUrl. Provide a preconfigured instance
+     *                                   to customize the underlying HTTP client.
      *
      * @see MethodOptions::$restore For automatic restore configuration
      */
@@ -41,6 +45,7 @@ class ClientOptions
         public Network $network,
         public string $rpcUrl,
         public ?LoggerInterface $logger = null,
+        public ?SorobanServer $server = null,
     ) {
     }
 }

--- a/Soneso/StellarSDK/Soroban/Contract/DeployRequest.php
+++ b/Soneso/StellarSDK/Soroban/Contract/DeployRequest.php
@@ -9,6 +9,7 @@ namespace Soneso\StellarSDK\Soroban\Contract;
 use Psr\Log\LoggerInterface;
 use Soneso\StellarSDK\Crypto\KeyPair;
 use Soneso\StellarSDK\Network;
+use Soneso\StellarSDK\Soroban\SorobanServer;
 use Soneso\StellarSDK\Xdr\XdrSCVal;
 
 /**
@@ -75,6 +76,13 @@ class DeployRequest
     public ?LoggerInterface $logger = null;
 
     /**
+     * @var SorobanServer|null $server RPC server instance to use. When null, one is created
+     * automatically from $rpcUrl. Provide a preconfigured instance to customize the underlying
+     * HTTP client.
+     */
+    public ?SorobanServer $server = null;
+
+    /**
      * Constructor.
      *
      * @param string $rpcUrl The URL of the RPC instance that will be used to deploy the contract.
@@ -86,6 +94,8 @@ class DeployRequest
      * @param string|null $salt Salt used to generate the contract's ID. Default: random.
      * @param MethodOptions|null $methodOptions method options used to fine tune the transaction. Default: new MethodOptions()
      * @param LoggerInterface|null $logger PSR-3 logger for debug output. Default: null (no logging).
+     * @param SorobanServer|null $server RPC server instance to use. When null, one is created
+     * automatically from $rpcUrl.
      */
     public function __construct(string $rpcUrl,
                                 Network $network,
@@ -94,7 +104,8 @@ class DeployRequest
                                 ?array $constructorArgs = null,
                                 ?string $salt = null,
                                 ?MethodOptions $methodOptions = null,
-                                ?LoggerInterface $logger = null)
+                                ?LoggerInterface $logger = null,
+                                ?SorobanServer $server = null)
     {
         $this->sourceAccountKeyPair = $sourceAccountKeyPair;
         $this->network = $network;
@@ -104,6 +115,7 @@ class DeployRequest
         $this->constructorArgs = $constructorArgs;
         $this->salt = $salt;
         $this->logger = $logger;
+        $this->server = $server;
     }
 
 }

--- a/Soneso/StellarSDK/Soroban/Contract/InstallRequest.php
+++ b/Soneso/StellarSDK/Soroban/Contract/InstallRequest.php
@@ -9,6 +9,7 @@ namespace Soneso\StellarSDK\Soroban\Contract;
 use Psr\Log\LoggerInterface;
 use Soneso\StellarSDK\Crypto\KeyPair;
 use Soneso\StellarSDK\Network;
+use Soneso\StellarSDK\Soroban\SorobanServer;
 
 /**
  * Request parameters for installing Soroban smart contract WASM code
@@ -35,6 +36,9 @@ class InstallRequest
      * @param KeyPair $sourceAccountKeyPair Keypair of the Stellar account that will send this transaction.
      *                                      The keypair must contain the private key for signing.
      * @param LoggerInterface|null $logger PSR-3 logger for debug output. Default: null (no logging).
+     * @param SorobanServer|null $server RPC server instance to use. When null, one is created
+     *                                   automatically from $rpcUrl. Provide a preconfigured instance
+     *                                   to customize the underlying HTTP client.
      */
     public function __construct(
         public string $wasmBytes,
@@ -42,6 +46,7 @@ class InstallRequest
         public Network $network,
         public KeyPair $sourceAccountKeyPair,
         public ?LoggerInterface $logger = null,
+        public ?SorobanServer $server = null,
     ) {
     }
 

--- a/Soneso/StellarSDK/Soroban/Contract/SorobanClient.php
+++ b/Soneso/StellarSDK/Soroban/Contract/SorobanClient.php
@@ -96,7 +96,7 @@ class SorobanClient
      * @throws Exception If the contract is not found or spec parsing fails
      */
     public static function forClientOptions(ClientOptions $options) : SorobanClient {
-        $server = new SorobanServer($options->rpcUrl);
+        $server = $options->server ?? new SorobanServer($options->rpcUrl);
         if ($options->logger !== null) {
             $server->setLogger($options->logger);
         }
@@ -138,7 +138,8 @@ class SorobanClient
             contractId: "ignored",
             network: $deployRequest->network,
             rpcUrl: $deployRequest->rpcUrl,
-            logger: $deployRequest->logger
+            logger: $deployRequest->logger,
+            server: $deployRequest->server
         );
         $options = new AssembledTransactionOptions(
             clientOptions:$clientOptions,
@@ -179,7 +180,8 @@ class SorobanClient
             contractId: "ignored",
             network: $installRequest->network,
             rpcUrl: $installRequest->rpcUrl,
-            logger: $installRequest->logger
+            logger: $installRequest->logger,
+            server: $installRequest->server
         );
         $options = new AssembledTransactionOptions(
             clientOptions:$clientOptions,

--- a/Soneso/StellarSDK/StellarSDK.php
+++ b/Soneso/StellarSDK/StellarSDK.php
@@ -563,6 +563,8 @@ class StellarSDK
                 }
             }
         }
+        // Collapse duplicate destinations so each account is queried at most once.
+        $destinations = array_unique($destinations);
         if (count($destinations) == 0) {
             return false;
         }

--- a/Soneso/StellarSDK/Util/StellarAmount.php
+++ b/Soneso/StellarSDK/Util/StellarAmount.php
@@ -53,7 +53,49 @@ class StellarAmount
      * @var BigInteger Maximum value that fits in a signed 64-bit integer (9223372036854775807)
      */
     protected BigInteger $maxSignedStroops64;
-    
+
+    /**
+     * @var BigInteger|null Shared, lazily created stroop scale factor.
+     */
+    private static ?BigInteger $stroopScaleCache = null;
+
+    /**
+     * @var BigInteger|null Shared, lazily created maximum signed 64-bit stroops value.
+     */
+    private static ?BigInteger $maxStroopsCache = null;
+
+    /**
+     * @var BigInteger|null Shared, lazily created zero value.
+     */
+    private static ?BigInteger $zeroCache = null;
+
+    /**
+     * Returns the shared stroop scale factor (10,000,000).
+     *
+     * BigInteger is immutable, so a single instance is reused across all
+     * StellarAmount objects instead of re-parsing the constant on each call.
+     */
+    private static function stroopScale(): BigInteger
+    {
+        return self::$stroopScaleCache ??= new BigInteger(StellarConstants::STROOP_SCALE);
+    }
+
+    /**
+     * Returns the shared maximum signed 64-bit stroops value (9223372036854775807).
+     */
+    private static function maxStroops(): BigInteger
+    {
+        return self::$maxStroopsCache ??= new BigInteger('9223372036854775807');
+    }
+
+    /**
+     * Returns the shared zero value.
+     */
+    private static function zero(): BigInteger
+    {
+        return self::$zeroCache ??= new BigInteger('0');
+    }
+
     /**
      * Returns the maximum supported amount
      *
@@ -62,7 +104,7 @@ class StellarAmount
      */
     public static function maximum() : StellarAmount
     {
-        return new StellarAmount(new BigInteger('9223372036854775807'));
+        return new StellarAmount(self::maxStroops());
     }
     
     /**
@@ -86,19 +128,18 @@ class StellarAmount
      */
     public function __construct(BigInteger $stroops)
     {
-        $this->stroopScaleBignum = new BigInteger(StellarConstants::STROOP_SCALE);
-        $this->maxSignedStroops64 = new BigInteger('9223372036854775807');
+        $this->stroopScaleBignum = self::stroopScale();
+        $this->maxSignedStroops64 = self::maxStroops();
         $this->stroops = $stroops;
-        
+
         // Ensure amount of stroops doesn't exceed the maximum
         $compared = $this->stroops->compare($this->maxSignedStroops64);
         if ($compared > 0) {
             throw new \InvalidArgumentException('Maximum value exceeded. Value cannot be larger than 9223372036854775807 stroops (922337203685.4775807 XLM)');
         }
-        
+
         // Ensure amount is not negative
-        $zero = new BigInteger('0');
-        $compared = $this->stroops->compare($zero);
+        $compared = $this->stroops->compare(self::zero());
         if ($compared < 0) {
             throw new \InvalidArgumentException('Amount cannot be negative');
         }
@@ -131,11 +172,11 @@ class StellarAmount
         $amountStr = str_replace(',', '', $decimalAmount);
         $amountStr = str_replace(' ', '', $amountStr);
         $parts = explode('.', $amountStr);
-        $unscaledAmount = new BigInteger('0');
+        $unscaledAmount = self::zero();
 
         // Everything to the left of the decimal point
         if ($parts[0]) {
-            $unscaledAmountLeft = (new BigInteger($parts[0]))->multiply(new BigInteger(StellarConstants::STROOP_SCALE));
+            $unscaledAmountLeft = (new BigInteger($parts[0]))->multiply(self::stroopScale());
             $unscaledAmount = $unscaledAmount->add($unscaledAmountLeft);
         }
 

--- a/Soneso/StellarSDK/Xdr/XdrDecoder.php
+++ b/Soneso/StellarSDK/Xdr/XdrDecoder.php
@@ -21,7 +21,7 @@ class XdrDecoder
     public static function unsignedInteger(string $xdr) : int {
         // unsigned 32-bit big-endian
         $unpacked = unpack('N', $xdr);
-        return array_pop($unpacked);
+        return $unpacked[1];
     }
     
     /**
@@ -37,7 +37,7 @@ class XdrDecoder
         
         $unpacked = unpack('l', $xdr);
         
-        return array_pop($unpacked);
+        return $unpacked[1];
     }
 
     /**
@@ -48,7 +48,7 @@ class XdrDecoder
     {
         // unsigned 64-bit big-endian
         $unpacked = unpack('J', $xdr);
-        return array_pop($unpacked);
+        return $unpacked[1];
     }
 
     /**
@@ -66,7 +66,7 @@ class XdrDecoder
         
         $unpacked = unpack('q', $xdr);
         
-        return array_pop($unpacked);
+        return $unpacked[1];
     }
 
     /**
@@ -88,9 +88,9 @@ class XdrDecoder
         if ($value !== 1 && $value !== 0) {
             throw new InvalidArgumentException('Unexpected XDR for a boolean value');
         }
-        
-        // Equivalent to 1 or 0 uint32
-        return (bool)self::unsignedInteger($xdr);
+
+        // $value is already the decoded 1 or 0 uint32.
+        return (bool)$value;
     }
 
     /**

--- a/Soneso/StellarSDK/Xdr/XdrEncoder.php
+++ b/Soneso/StellarSDK/Xdr/XdrEncoder.php
@@ -16,6 +16,8 @@ use phpseclib3\Math\BigInteger;
  */
 class XdrEncoder
 {
+    private static ?bool $nativeIsBigEndian = null; // used for caching whether the current platform is big endian.
+
     /**
      * @param string $value
      * @param int|null $expectedLength in bytes
@@ -282,6 +284,9 @@ class XdrEncoder
      */
     private static function nativeIsBigEndian(): bool
     {
-        return pack('L', 1) === pack('N', 1);
+        if (null === self::$nativeIsBigEndian) {
+            self::$nativeIsBigEndian = pack('L', 1) === pack('N', 1);
+        }
+        return self::$nativeIsBigEndian;
     }
 }

--- a/Soneso/StellarSDK/Xdr/XdrEncoder.php
+++ b/Soneso/StellarSDK/Xdr/XdrEncoder.php
@@ -26,11 +26,12 @@ class XdrEncoder
      */
     public static function opaqueFixed(string $value, ?int $expectedLength = null, bool $padUnexpectedLength = false): string
     {
+        $length = strlen($value);
         // Length greater than expected length is always an error
-        if ($expectedLength && strlen($value) > $expectedLength) throw new InvalidArgumentException(sprintf('Unexpected length for value. Has length %s, expected %s', strlen($value), $expectedLength));
-        if ($expectedLength && !$padUnexpectedLength && strlen($value) != $expectedLength) throw new InvalidArgumentException(sprintf('Unexpected length for value. Has length %s, expected %s', strlen($value), $expectedLength));
+        if ($expectedLength && $length > $expectedLength) throw new InvalidArgumentException(sprintf('Unexpected length for value. Has length %s, expected %s', $length, $expectedLength));
+        if ($expectedLength && !$padUnexpectedLength && $length != $expectedLength) throw new InvalidArgumentException(sprintf('Unexpected length for value. Has length %s, expected %s', $length, $expectedLength));
 
-        if ($expectedLength && strlen($value) != $expectedLength) {
+        if ($expectedLength && $length != $expectedLength) {
             $value = self::applyPadding($value, $expectedLength);
         }
 
@@ -47,7 +48,7 @@ class XdrEncoder
      */
     public static function opaqueVariable(string $value): string
     {
-        $maxLength = pow(2, 32) - 1;
+        $maxLength = 4294967295;
         if (strlen($value) > $maxLength) throw new InvalidArgumentException(sprintf('Value of length %s is greater than the maximum allowed length of %s', strlen($value), $maxLength));
 
         $bytes = '';
@@ -197,7 +198,7 @@ class XdrEncoder
      */
     public static function string(string $value, ?int $maximumLength = null): string
     {
-        if ($maximumLength === null) $maximumLength = pow(2, 32) - 1;
+        if ($maximumLength === null) $maximumLength = 4294967295;
 
         if (strlen($value) > $maximumLength) throw new InvalidArgumentException('string exceeds maximum length');
 

--- a/Soneso/StellarSDKTests/Integration/SEP010Test.php
+++ b/Soneso/StellarSDKTests/Integration/SEP010Test.php
@@ -1,0 +1,76 @@
+<?php declare(strict_types=1);
+
+// Copyright 2026 The Stellar PHP SDK Authors. All rights reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+namespace Soneso\StellarSDKTests\Integration;
+
+use Exception;
+use GuzzleHttp\Client;
+use PHPUnit\Framework\TestCase;
+use Soneso\StellarSDK\Crypto\KeyPair;
+use Soneso\StellarSDK\Network;
+use Soneso\StellarSDK\SEP\WebAuth\WebAuth;
+
+/**
+ * Integration tests for SEP-10 Web Authentication against live services.
+ *
+ * These exercise the full authentication flow over the network and are not part
+ * of the unit suite.
+ */
+class SEP010Test extends TestCase
+{
+    /**
+     * SEP-10 authentication with testanchor.stellar.org.
+     */
+    public function testWithStellarTestAnchor(): void {
+        $webAuth = WebAuth::fromDomain("testanchor.stellar.org", Network::testnet());
+
+        $userKeyPair = KeyPair::random();
+        $userAccountId = $userKeyPair->getAccountId();
+        $jwt = $webAuth->jwtToken($userAccountId, [$userKeyPair]);
+        $this->assertNotEmpty($jwt);
+    }
+
+    /**
+     * SEP-10 authentication with testanchor.stellar.org and client domain.
+     *
+     * Uses phpsepsigner.stellargate.com as the client domain signing server.
+     *
+     * @see https://github.com/Soneso/php-server-signer
+     */
+    public function testWithStellarTestAnchorAndClientDomain(): void {
+        $webAuth = WebAuth::fromDomain("testanchor.stellar.org", Network::testnet());
+
+        $clientDomain = "phpsepsigner.stellargate.com";
+        $bearerToken = "103e1e6234ac2cc1a30d983dba367db2b194ea5b269433c316ad36d21e1e8235";
+
+        $callback = function (string $b64EncodedEnvelope) use ($bearerToken) {
+            $httpClient = new Client();
+            $response = $httpClient->request('POST', 'https://phpsepsigner.stellargate.com/sign-sep-10', [
+                'json' => [
+                    'transaction' => $b64EncodedEnvelope,
+                    'network_passphrase' => 'Test SDF Network ; September 2015'
+                ],
+                'headers' => ['Authorization' => 'Bearer ' . $bearerToken]
+            ]);
+            $content = $response->getBody()->__toString();
+            $jsonData = json_decode($content, true);
+            if (isset($jsonData['transaction'])) {
+                return $jsonData['transaction'];
+            }
+            throw new Exception("Invalid server response: " . $content);
+        };
+
+        $userKeyPair = KeyPair::random();
+        $userAccountId = $userKeyPair->getAccountId();
+        $jwt = $webAuth->jwtToken(
+            $userAccountId,
+            [$userKeyPair],
+            clientDomain: $clientDomain,
+            clientDomainSigningCallback: $callback
+        );
+        $this->assertNotEmpty($jwt);
+    }
+}

--- a/Soneso/StellarSDKTests/Unit/Core/AssetTest.php
+++ b/Soneso/StellarSDKTests/Unit/Core/AssetTest.php
@@ -13,6 +13,7 @@ use Soneso\StellarSDK\Asset;
 use Soneso\StellarSDK\AssetTypeCreditAlphanum4;
 use Soneso\StellarSDK\AssetTypeCreditAlphanum12;
 use Soneso\StellarSDK\AssetTypeNative;
+use Soneso\StellarSDK\AssetTypePoolShare;
 use function PHPUnit\Framework\assertEquals;
 use function PHPUnit\Framework\assertNotNull;
 use function PHPUnit\Framework\assertNull;
@@ -266,5 +267,27 @@ class AssetTest extends TestCase
 
         $asset5 = Asset::createNonNativeAsset("EUR", $this->issuerAccountId);
         assertTrue($asset3->getCode() !== $asset5->getCode());
+    }
+
+    public function testPoolShareTypeConstantMatchesHorizonValue()
+    {
+        // Horizon reports liquidity pool share balances with this asset type string.
+        assertEquals("liquidity_pool_shares", Asset::TYPE_POOL_SHARE);
+    }
+
+    public function testPoolShareAssetTypeMatchesConstant()
+    {
+        $assetA = new AssetTypeNative();
+        $assetB = Asset::createNonNativeAsset("USD", $this->issuerAccountId);
+        $poolShare = new AssetTypePoolShare($assetA, $assetB);
+
+        assertEquals(Asset::TYPE_POOL_SHARE, $poolShare->getType());
+    }
+
+    public function testCreateRejectsPoolShareTypeWithClearMessage()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('construct AssetTypePoolShare directly');
+        Asset::create(Asset::TYPE_POOL_SHARE);
     }
 }

--- a/Soneso/StellarSDKTests/Unit/Core/MemoTest.php
+++ b/Soneso/StellarSDKTests/Unit/Core/MemoTest.php
@@ -255,4 +255,97 @@ class MemoTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $memo = new Memo(Memo::MEMO_TYPE_TEXT, str_repeat("a", 29));
     }
+
+    public function testIdMemoFromStringMaxValueRoundTrip()
+    {
+        $memo = Memo::id("18446744073709551615");
+
+        assertEquals("00000002ffffffffffffffff", bin2hex($memo->toXdr()->encode()));
+        assertEquals("18446744073709551615", $memo->getIdAsString());
+
+        $parsed = Memo::fromXdr($memo->toXdr());
+        assertEquals("18446744073709551615", $parsed->getValue());
+        assertEquals("18446744073709551615", $parsed->getIdAsString());
+    }
+
+    public function testIdMemoUpperRangeDecodesAsUnsignedString()
+    {
+        // id = 2^64 - 5, which does not fit in a signed PHP int
+        $bytes = "\x00\x00\x00\x02\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFB";
+        $memo = Memo::fromXdr(\Soneso\StellarSDK\Xdr\XdrMemo::decode(new \Soneso\StellarSDK\Xdr\XdrBuffer($bytes)));
+
+        assertEquals("18446744073709551611", $memo->getValue());
+        assertEquals("18446744073709551611", $memo->getIdAsString());
+        assertEquals("18446744073709551611", $memo->valueAsString());
+        assertEquals($bytes, $memo->toXdr()->encode());
+    }
+
+    public function testIdMemoSmallStringRoundTrip()
+    {
+        $memo = Memo::id("123");
+        $parsed = Memo::fromXdr($memo->toXdr());
+
+        assertEquals(123, $parsed->getValue());
+        assertEquals("123", $parsed->getIdAsString());
+    }
+
+    public function testIdMemoRejectsNegativeIntInFactory()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("value cannot be negative");
+        Memo::id(-5);
+    }
+
+    public function testIdMemoRejectsNegativeIntInConstructor()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("value cannot be negative");
+        new Memo(Memo::MEMO_TYPE_ID, -5);
+    }
+
+    public function testIdMemoRejectsStringAboveUint64Max()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("value cannot be larger than 18446744073709551615");
+        Memo::id("18446744073709551616");
+    }
+
+    public function testIdMemoRejectsNonIntNonStringValue()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("id memo value must be an int or an unsigned decimal string");
+        new Memo(Memo::MEMO_TYPE_ID, 1.5);
+    }
+
+    public function testIdMemoRejectsMalformedStrings()
+    {
+        foreach (["abc", "-5", "01", "", "1.5"] as $bad) {
+            try {
+                Memo::id($bad);
+                $this->fail("expected rejection of id memo value: " . $bad);
+            } catch (InvalidArgumentException $e) {
+                assertNotNull($e->getMessage());
+            }
+        }
+    }
+
+    public function testGetIdAsString()
+    {
+        assertEquals("12345", Memo::id(12345)->getIdAsString());
+        assertNull(Memo::text("hello")->getIdAsString());
+        assertNull(Memo::none()->getIdAsString());
+    }
+
+    public function testIdMemoIntStringCrossoverBoundary()
+    {
+        // PHP_INT_MAX as a string stays representable without wrapping.
+        $maxInt = Memo::id("9223372036854775807");
+        assertEquals("000000027fffffffffffffff", bin2hex($maxInt->toXdr()->encode()));
+        assertEquals(PHP_INT_MAX, Memo::fromXdr($maxInt->toXdr())->getValue());
+
+        // PHP_INT_MAX + 1 is the first value that requires the string representation.
+        $aboveMax = Memo::id("9223372036854775808");
+        assertEquals("000000028000000000000000", bin2hex($aboveMax->toXdr()->encode()));
+        assertEquals("9223372036854775808", Memo::fromXdr($aboveMax->toXdr())->getValue());
+    }
 }

--- a/Soneso/StellarSDKTests/Unit/Core/StellarSDKTest.php
+++ b/Soneso/StellarSDKTests/Unit/Core/StellarSDKTest.php
@@ -16,9 +16,12 @@ use Soneso\StellarSDK\Transaction;
 use Soneso\StellarSDK\Network;
 use Soneso\StellarSDK\TransactionBuilder;
 use Soneso\StellarSDK\Crypto\KeyPair;
+use Soneso\StellarSDK\Account;
 use Soneso\StellarSDK\Asset;
 use Soneso\StellarSDK\CreateAccountOperationBuilder;
 use Soneso\StellarSDK\Memo;
+use Soneso\StellarSDK\PaymentOperationBuilder;
+use phpseclib3\Math\BigInteger;
 use Soneso\StellarSDK\Requests\AccountsRequestBuilder;
 use Soneso\StellarSDK\Requests\AssetsRequestBuilder;
 use Soneso\StellarSDK\Requests\EffectsRequestBuilder;
@@ -947,5 +950,110 @@ class StellarSDKTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Service URL must use HTTPS');
         new StellarSDK('http://horizon-testnet.stellar.org');
+    }
+
+    /**
+     * Builds a minimal account JSON response for the given account id.
+     * Data values are base64-encoded, as Horizon returns them.
+     *
+     * @param array<string, string> $data raw (non-encoded) data entries.
+     */
+    private function accountJson(string $accountId, array $data = []): string
+    {
+        $encodedData = [];
+        foreach ($data as $k => $v) {
+            $encodedData[$k] = base64_encode($v);
+        }
+        return json_encode([
+            '_links' => ['self' => ['href' => 'https://horizon-testnet.stellar.org/accounts/' . $accountId]],
+            'id' => $accountId,
+            'account_id' => $accountId,
+            'sequence' => '123456789012',
+            'subentry_count' => 0,
+            'last_modified_ledger' => 1234567,
+            'last_modified_time' => '2024-01-20T12:00:00Z',
+            'thresholds' => ['low_threshold' => 0, 'med_threshold' => 0, 'high_threshold' => 0],
+            'flags' => ['auth_required' => false, 'auth_revocable' => false, 'auth_immutable' => false, 'auth_clawback_enabled' => false],
+            'balances' => [['balance' => '100.0000000', 'asset_type' => 'native']],
+            'signers' => [['key' => $accountId, 'weight' => 1, 'type' => 'ed25519_public_key']],
+            'data' => (object) $encodedData,
+            'num_sponsoring' => 0,
+            'num_sponsored' => 0,
+            'paging_token' => $accountId,
+        ]);
+    }
+
+    private function paymentTransaction(string $sourceAccountId, string ...$destinationAccountIds): Transaction
+    {
+        $builder = new TransactionBuilder(new Account($sourceAccountId, new BigInteger('123')));
+        foreach ($destinationAccountIds as $destinationAccountId) {
+            $builder->addOperation(
+                (new PaymentOperationBuilder($destinationAccountId, Asset::native(), '10'))->build()
+            );
+        }
+        return $builder->build();
+    }
+
+    public function testCheckMemoRequiredReturnsDestinationWhenFlagSet(): void
+    {
+        $source = KeyPair::random()->getAccountId();
+        $destination = KeyPair::random()->getAccountId();
+        $sdk = $this->createMockedSdk([
+            new Response(200, [], $this->accountJson($destination, ['config.memo_required' => '1'])),
+        ]);
+
+        $result = $sdk->checkMemoRequired($this->paymentTransaction($source, $destination));
+        $this->assertEquals($destination, $result);
+    }
+
+    public function testCheckMemoRequiredFalseWhenFlagNotSet(): void
+    {
+        $source = KeyPair::random()->getAccountId();
+        $destination = KeyPair::random()->getAccountId();
+        $sdk = $this->createMockedSdk([
+            new Response(200, [], $this->accountJson($destination)),
+        ]);
+
+        $this->assertFalse($sdk->checkMemoRequired($this->paymentTransaction($source, $destination)));
+    }
+
+    public function testCheckMemoRequiredFalseWhenMemoPresent(): void
+    {
+        $source = KeyPair::random()->getAccountId();
+        $destination = KeyPair::random()->getAccountId();
+        // Empty mock queue: a memo is already set, so no account lookup must happen.
+        $sdk = $this->createMockedSdk([]);
+
+        $builder = new TransactionBuilder(new Account($source, new BigInteger('123')));
+        $builder->addOperation((new PaymentOperationBuilder($destination, Asset::native(), '10'))->build());
+        $builder->addMemo(Memo::text('hello'));
+        $this->assertFalse($sdk->checkMemoRequired($builder->build()));
+    }
+
+    public function testCheckMemoRequiredFalseWhenNoPaymentOperations(): void
+    {
+        $source = KeyPair::random()->getAccountId();
+        $newAccount = KeyPair::random()->getAccountId();
+        // Empty mock queue: create-account is not a destination-bearing payment, so no lookup happens.
+        $sdk = $this->createMockedSdk([]);
+
+        $builder = new TransactionBuilder(new Account($source, new BigInteger('123')));
+        $builder->addOperation((new CreateAccountOperationBuilder($newAccount, '10'))->build());
+        $this->assertFalse($sdk->checkMemoRequired($builder->build()));
+    }
+
+    public function testCheckMemoRequiredDeduplicatesDestinations(): void
+    {
+        $source = KeyPair::random()->getAccountId();
+        $destination = KeyPair::random()->getAccountId();
+        // Two operations to the SAME destination, but only ONE mocked account response.
+        // Without de-duplication the second lookup would hit an empty mock queue and throw.
+        $sdk = $this->createMockedSdk([
+            new Response(200, [], $this->accountJson($destination)),
+        ]);
+
+        $this->assertFalse(
+            $sdk->checkMemoRequired($this->paymentTransaction($source, $destination, $destination))
+        );
     }
 }

--- a/Soneso/StellarSDKTests/Unit/Crypto/KeyPairTest.php
+++ b/Soneso/StellarSDKTests/Unit/Crypto/KeyPairTest.php
@@ -7,6 +7,7 @@
 namespace Soneso\StellarSDKTests\Unit\Crypto;
 
 use Exception;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Soneso\StellarSDK\Crypto\CryptoException;
 use Soneso\StellarSDK\Crypto\KeyPair;
@@ -577,6 +578,57 @@ class KeyPairTest extends TestCase
         $signature = hex2bin($hexSignature);
 
         assertTrue($keyPair->verifyMessage($binaryMessage, $signature));
+    }
+
+    public function testConstructorRejectsShortPublicKey()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Public key must be 32 bytes, got 31');
+        new KeyPair(str_repeat("\xAB", 31));
+    }
+
+    public function testConstructorRejectsLongPublicKey()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Public key must be 32 bytes, got 33');
+        new KeyPair(str_repeat("\xAB", 33));
+    }
+
+    public function testConstructorRejectsShortPrivateKey()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Private key must be 32 bytes, got 16');
+        new KeyPair(str_repeat("\xAB", 32), str_repeat("\xCD", 16));
+    }
+
+    public function testFromPublicKeyRejectsWrongLength()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Public key must be 32 bytes');
+        KeyPair::fromPublicKey(str_repeat("\xAB", 16));
+    }
+
+    public function testFromPublicKeyRejectsEmptyKey()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Public key must be 32 bytes, got 0');
+        KeyPair::fromPublicKey('');
+    }
+
+    public function testFromPrivateKeyRejectsWrongLength()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Private key must be 32 bytes, got 16');
+        KeyPair::fromPrivateKey(str_repeat("\xCD", 16));
+    }
+
+    public function testConstructorAcceptsValidKeyLengths()
+    {
+        $random = KeyPair::random();
+        $keyPair = new KeyPair($random->getPublicKey(), $random->getPrivateKey());
+
+        assertEquals($random->getAccountId(), $keyPair->getAccountId());
+        assertEquals($random->getSecretSeed(), $keyPair->getSecretSeed());
     }
 
 }

--- a/Soneso/StellarSDKTests/Unit/Crypto/PayloadSignerTest.php
+++ b/Soneso/StellarSDKTests/Unit/Crypto/PayloadSignerTest.php
@@ -43,6 +43,33 @@ class PayloadSignerTest extends TestCase
         $this->assertEquals(implode(array_map("chr", $arr)),$signature->getHint());
     }
 
+    public function testSignPayloadSignerHintComputation(): void
+    {
+        $seedBytes = hex2bin($this->seed);
+        $keypair = KeyPair::fromPrivateKey($seedBytes);
+        $keyHint = $keypair->getHint();
+        // The hint is the last 4 bytes of the payload (the whole payload, right
+        // padded with zeros, when shorter than 4) XORed byte-for-byte with the
+        // key hint (CAP-40). Covers the empty edge, the sub-4-byte padding, the
+        // 4-byte boundary, and the longer-than-4 slice, with high bytes to
+        // confirm binary safety.
+        $source = "\xff\x80\x01\x7f\x00\xfe\x42\x99";
+        foreach ([0, 1, 2, 3, 4, 8] as $len) {
+            $payload = substr($source, 0, $len);
+            $payloadHint = $len >= 4
+                ? substr($payload, $len - 4, 4)
+                : $payload . str_repeat("\x00", 4 - $len);
+            $expected = '';
+            for ($i = 0; $i < 4; $i++) {
+                $expected .= chr(ord($payloadHint[$i]) ^ ord($keyHint[$i]));
+            }
+            $signature = $keypair->signPayloadDecorated($payload);
+            $this->assertEquals($expected, $signature->getHint(), "hint mismatch for payload length $len");
+        }
+        // An empty payload leaves the key hint unchanged.
+        $this->assertEquals($keyHint, $keypair->signPayloadDecorated("")->getHint());
+    }
+
     public function testItCreatesSignedPayloadSigner(): void {
         $accountStrKey = "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ";
         $p16 = "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20";

--- a/Soneso/StellarSDKTests/Unit/Requests/RequestBuilderStreamTest.php
+++ b/Soneso/StellarSDKTests/Unit/Requests/RequestBuilderStreamTest.php
@@ -1,0 +1,210 @@
+<?php declare(strict_types=1);
+
+// Copyright 2024 The Stellar PHP SDK Authors. All rights reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+namespace Soneso\StellarSDKTests\Unit\Requests;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response as HttpResponse;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+use Soneso\StellarSDK\Requests\RequestBuilder;
+use Soneso\StellarSDK\Responses\Response;
+
+/**
+ * Tests the SSE line buffering / event extraction used by RequestBuilder::getAndStream.
+ */
+class RequestBuilderStreamTest extends TestCase
+{
+    /**
+     * Invokes the private static RequestBuilder::consumeStreamEvents with a by-reference buffer.
+     *
+     * @return array{events: array<int, mixed>, stop: bool}
+     */
+    private function consume(string &$buffer): array
+    {
+        $method = new ReflectionMethod(RequestBuilder::class, 'consumeStreamEvents');
+        $method->setAccessible(true);
+        $args = array(&$buffer);
+        return $method->invokeArgs(null, $args);
+    }
+
+    public function testParsesMultipleDataLinesInOneChunk(): void
+    {
+        $buffer = 'data: {"id":"1"}' . "\n" . 'data: {"id":"2"}' . "\n";
+        $result = $this->consume($buffer);
+
+        $this->assertFalse($result['stop']);
+        $this->assertCount(2, $result['events']);
+        $this->assertEquals('1', $result['events'][0]['id']);
+        $this->assertEquals('2', $result['events'][1]['id']);
+        $this->assertSame('', $buffer);
+    }
+
+    public function testRetainsPartialTrailingLine(): void
+    {
+        $buffer = 'data: {"id":"1"}' . "\n" . 'data: {"id":"2"';
+        $result = $this->consume($buffer);
+
+        $this->assertCount(1, $result['events']);
+        $this->assertEquals('1', $result['events'][0]['id']);
+        // The incomplete line (no trailing newline) is kept for the next read.
+        $this->assertSame('data: {"id":"2"', $buffer);
+    }
+
+    public function testLineSplitAcrossChunks(): void
+    {
+        $buffer = 'data: {"id":"1"';
+        $result = $this->consume($buffer);
+        $this->assertCount(0, $result['events']);
+        $this->assertSame('data: {"id":"1"', $buffer);
+
+        // The next chunk completes the first line and adds a second.
+        $buffer .= '}' . "\n" . 'data: {"id":"2"}' . "\n";
+        $result = $this->consume($buffer);
+        $this->assertCount(2, $result['events']);
+        $this->assertEquals('1', $result['events'][0]['id']);
+        $this->assertEquals('2', $result['events'][1]['id']);
+        $this->assertSame('', $buffer);
+    }
+
+    public function testIgnoresEmptyHelloAndNonDataLines(): void
+    {
+        $buffer = "\n"
+            . 'data: "hello"' . "\n"
+            . ': keep-alive comment' . "\n"
+            . 'event: message' . "\n"
+            . 'data: {"id":"1"}' . "\n";
+        $result = $this->consume($buffer);
+
+        $this->assertFalse($result['stop']);
+        $this->assertCount(1, $result['events']);
+        $this->assertEquals('1', $result['events'][0]['id']);
+        $this->assertSame('', $buffer);
+    }
+
+    public function testByebyeStopsAndSignalsReconnect(): void
+    {
+        $buffer = 'data: {"id":"1"}' . "\n"
+            . 'data: "byebye"' . "\n"
+            . 'data: {"id":"2"}' . "\n";
+        $result = $this->consume($buffer);
+
+        $this->assertTrue($result['stop']);
+        // Events before the byebye line are returned; parsing stops at byebye.
+        $this->assertCount(1, $result['events']);
+        $this->assertEquals('1', $result['events'][0]['id']);
+        // Lines after byebye remain unconsumed in the buffer.
+        $this->assertSame('data: {"id":"2"}' . "\n", $buffer);
+    }
+
+    public function testIgnoresUndecodableData(): void
+    {
+        $buffer = 'data: not-json' . "\n" . 'data: {"id":"1"}' . "\n";
+        $result = $this->consume($buffer);
+
+        $this->assertCount(1, $result['events']);
+        $this->assertEquals('1', $result['events'][0]['id']);
+        $this->assertSame('', $buffer);
+    }
+
+    public function testEmptyBufferYieldsNoEvents(): void
+    {
+        $buffer = '';
+        $result = $this->consume($buffer);
+
+        $this->assertFalse($result['stop']);
+        $this->assertCount(0, $result['events']);
+        $this->assertSame('', $buffer);
+    }
+
+    public function testByebyeWithNoTrailingLinesLeavesEmptyBuffer(): void
+    {
+        $buffer = 'data: {"id":"1"}' . "\n" . 'data: "byebye"' . "\n";
+        $result = $this->consume($buffer);
+
+        $this->assertTrue($result['stop']);
+        $this->assertCount(1, $result['events']);
+        $this->assertSame('', $buffer);
+    }
+
+    public function testCarriageReturnLineEndingsStillDecode(): void
+    {
+        // Lines are split on "\n" only; a trailing "\r" is tolerated by json_decode.
+        $buffer = 'data: {"id":"1"}' . "\r\n" . 'data: {"id":"2"}' . "\r\n";
+        $result = $this->consume($buffer);
+
+        $this->assertFalse($result['stop']);
+        $this->assertCount(2, $result['events']);
+        $this->assertEquals('1', $result['events'][0]['id']);
+        $this->assertEquals('2', $result['events'][1]['id']);
+        $this->assertSame('', $buffer);
+    }
+
+    /**
+     * Returns a concrete RequestBuilder backed by a mocked HTTP client that
+     * replies with the given streamed response bodies.
+     */
+    private function builderWithStreamedResponses(string ...$bodies): RequestBuilder
+    {
+        $responses = array_map(static fn (string $b) => new HttpResponse(200, [], $b), $bodies);
+        $client = new Client(['handler' => HandlerStack::create(new MockHandler($responses))]);
+        return new class($client) extends RequestBuilder {
+            public function execute(): Response
+            {
+                throw new \RuntimeException('not used in this test');
+            }
+        };
+    }
+
+    public function testGetAndStreamDispatchesEventsInOrderAndSkipsHandshake(): void
+    {
+        $sse = 'data: "hello"' . "\n"
+            . 'data: {"id":"1"}' . "\n"
+            . 'data: {"id":"2"}' . "\n";
+        $builder = $this->builderWithStreamedResponses($sse);
+
+        $received = [];
+        try {
+            // getAndStream loops forever, reconnecting when a stream ends. After the
+            // single mocked response is consumed the reconnect hits an empty mock
+            // queue, which throws and ends the otherwise-infinite loop.
+            $builder->getAndStream('/ledgers', function ($event) use (&$received) {
+                $received[] = $event;
+            });
+            $this->fail('expected the exhausted mock queue to end the stream loop');
+        } catch (\Throwable $e) {
+            // expected once the mock queue is empty on reconnect
+        }
+
+        $this->assertCount(2, $received);
+        $this->assertEquals('1', $received[0]['id']);
+        $this->assertEquals('2', $received[1]['id']);
+    }
+
+    public function testGetAndStreamStopsDispatchingAtByebye(): void
+    {
+        $sse = 'data: {"id":"1"}' . "\n"
+            . 'data: "byebye"' . "\n"
+            . 'data: {"id":"2"}' . "\n";
+        $builder = $this->builderWithStreamedResponses($sse);
+
+        $received = [];
+        try {
+            $builder->getAndStream('/ledgers', function ($event) use (&$received) {
+                $received[] = $event;
+            });
+            $this->fail('expected the exhausted mock queue to end the stream loop');
+        } catch (\Throwable $e) {
+            // expected: after byebye triggers a reconnect, the mock queue is empty
+        }
+
+        // Only the event before "byebye" is dispatched; the line after it is not.
+        $this->assertCount(1, $received);
+        $this->assertEquals('1', $received[0]['id']);
+    }
+}

--- a/Soneso/StellarSDKTests/Unit/SEP/CrossBorderPayments/CrossBorderPaymentsTest.php
+++ b/Soneso/StellarSDKTests/Unit/SEP/CrossBorderPayments/CrossBorderPaymentsTest.php
@@ -6,11 +6,13 @@
 
 namespace Soneso\StellarSDKTests\Unit\SEP\CrossBorderPayments;
 
+use Exception;
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\Psr7\Response;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 use Soneso\StellarSDK\SEP\CrossBorderPayments\CrossBorderPaymentsService;
@@ -20,6 +22,7 @@ use Soneso\StellarSDK\SEP\CrossBorderPayments\SEP31PostTransactionsRequest;
 use Soneso\StellarSDK\SEP\CrossBorderPayments\SEP31TransactionCallbackNotSupportedException;
 use Soneso\StellarSDK\SEP\CrossBorderPayments\SEP31TransactionInfoNeededException;
 use Soneso\StellarSDK\SEP\CrossBorderPayments\SEP31TransactionNotFoundException;
+use Soneso\StellarSDK\SEP\CrossBorderPayments\SEP31UnknownResponseException;
 
 class CrossBorderPaymentsTest extends TestCase
 {
@@ -391,5 +394,233 @@ class CrossBorderPaymentsTest extends TestCase
             $thrown = true;
         }
         $this->assertTrue($thrown);
+    }
+
+    public function testFromDomain(): void {
+        $toml = 'DIRECT_PAYMENT_SERVER="https://test.direct-payment.com"';
+        $mock = new MockHandler([
+            new Response(200, [], $toml),
+            new Response(200, [], $this->infoResponse),
+        ]);
+
+        $httpClient = new Client(['handler' => HandlerStack::create($mock)]);
+        $service = CrossBorderPaymentsService::fromDomain('example.com', $httpClient);
+        $response = $service->info($this->jwtToken);
+        $this->assertArrayHasKey('USDC', $response->receiveAssets);
+    }
+
+    public function testFromDomainWithoutDirectPaymentServer(): void {
+        $toml = 'VERSION="2.0.0"';
+        $mock = new MockHandler([
+            new Response(200, [], $toml),
+        ]);
+
+        $httpClient = new Client(['handler' => HandlerStack::create($mock)]);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('No anchor direct payment service found in stellar.toml');
+        CrossBorderPaymentsService::fromDomain('example.com', $httpClient);
+    }
+
+    // Error path tests
+
+    public function testConstructorRejectsHttpServiceAddress(): void {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Service URL must use HTTPS');
+        new CrossBorderPaymentsService('http://api.stellar.org/direct-payment');
+    }
+
+    public function testInfoWithBadRequestError(): void {
+        $mock = new MockHandler([
+            new Response(400, [], json_encode(['error' => 'invalid lang code'])),
+        ]);
+
+        $httpClient = new Client(['handler' => HandlerStack::create($mock)]);
+        $service = new CrossBorderPaymentsService($this->serviceAddress, $httpClient);
+
+        try {
+            $service->info($this->jwtToken);
+            $this->fail('Expected SEP31BadRequestException was not thrown');
+        } catch (SEP31BadRequestException $e) {
+            $this->assertEquals('invalid lang code', $e->getMessage());
+            $this->assertEquals(400, $e->getCode());
+        }
+    }
+
+    public function testInfoWithForbiddenError(): void {
+        $mock = new MockHandler([
+            new Response(403, [], json_encode(['error' => 'account not authorized'])),
+        ]);
+
+        $httpClient = new Client(['handler' => HandlerStack::create($mock)]);
+        $service = new CrossBorderPaymentsService($this->serviceAddress, $httpClient);
+
+        try {
+            $service->info($this->jwtToken);
+            $this->fail('Expected SEP31UnknownResponseException was not thrown');
+        } catch (SEP31UnknownResponseException $e) {
+            $this->assertEquals('account not authorized', $e->getMessage());
+            $this->assertEquals(403, $e->getCode());
+        }
+    }
+
+    public function testInfoWithServerErrorAndNonJsonBody(): void {
+        // A non-JSON body must surface as the raw response content.
+        $mock = new MockHandler([
+            new Response(500, [], 'internal server error'),
+        ]);
+
+        $httpClient = new Client(['handler' => HandlerStack::create($mock)]);
+        $service = new CrossBorderPaymentsService($this->serviceAddress, $httpClient);
+
+        try {
+            $service->info($this->jwtToken);
+            $this->fail('Expected SEP31UnknownResponseException was not thrown');
+        } catch (SEP31UnknownResponseException $e) {
+            $this->assertEquals('internal server error', $e->getMessage());
+            $this->assertEquals(500, $e->getCode());
+        }
+    }
+
+    public function testPostTransactionsWithServerError(): void {
+        $mock = new MockHandler([
+            new Response(500, [], json_encode(['error' => 'database unavailable'])),
+        ]);
+
+        $httpClient = new Client(['handler' => HandlerStack::create($mock)]);
+        $service = new CrossBorderPaymentsService($this->serviceAddress, $httpClient);
+        $request = new SEP31PostTransactionsRequest(
+            amount: 100.0,
+            assetCode: 'USDC',
+        );
+
+        try {
+            $service->postTransactions($request, $this->jwtToken);
+            $this->fail('Expected SEP31UnknownResponseException was not thrown');
+        } catch (SEP31UnknownResponseException $e) {
+            $this->assertEquals('database unavailable', $e->getMessage());
+            $this->assertEquals(500, $e->getCode());
+        }
+    }
+
+    public function testGetTransactionWithBadRequestError(): void {
+        $mock = new MockHandler([
+            new Response(400, [], json_encode(['error' => 'invalid transaction id'])),
+        ]);
+
+        $httpClient = new Client(['handler' => HandlerStack::create($mock)]);
+        $service = new CrossBorderPaymentsService($this->serviceAddress, $httpClient);
+
+        try {
+            $service->getTransaction('82fhs729f63dh0v4', $this->jwtToken);
+            $this->fail('Expected SEP31BadRequestException was not thrown');
+        } catch (SEP31BadRequestException $e) {
+            $this->assertEquals('invalid transaction id', $e->getMessage());
+            $this->assertEquals(400, $e->getCode());
+        }
+    }
+
+    public function testGetTransactionWithServerError(): void {
+        $mock = new MockHandler([
+            new Response(500, [], json_encode(['error' => 'unexpected failure'])),
+        ]);
+
+        $httpClient = new Client(['handler' => HandlerStack::create($mock)]);
+        $service = new CrossBorderPaymentsService($this->serviceAddress, $httpClient);
+
+        try {
+            $service->getTransaction('82fhs729f63dh0v4', $this->jwtToken);
+            $this->fail('Expected SEP31UnknownResponseException was not thrown');
+        } catch (SEP31UnknownResponseException $e) {
+            $this->assertEquals('unexpected failure', $e->getMessage());
+            $this->assertEquals(500, $e->getCode());
+        }
+    }
+
+    public function testGetTransactionRejectsPathTraversalId(): void {
+        $mock = new MockHandler([]);
+        $httpClient = new Client(['handler' => HandlerStack::create($mock)]);
+        $service = new CrossBorderPaymentsService($this->serviceAddress, $httpClient);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid value for');
+        $service->getTransaction('../admin', $this->jwtToken);
+    }
+
+    public function testPutTransactionCallbackWithBadRequestError(): void {
+        $mock = new MockHandler([
+            new Response(400, [], json_encode(['error' => 'invalid callback url'])),
+        ]);
+
+        $httpClient = new Client(['handler' => HandlerStack::create($mock)]);
+        $service = new CrossBorderPaymentsService($this->serviceAddress, $httpClient);
+
+        try {
+            $service->putTransactionCallback(
+                '82fhs729f63dh0v4',
+                'https://sendinganchor.com/statusCallback',
+                $this->jwtToken
+            );
+            $this->fail('Expected SEP31BadRequestException was not thrown');
+        } catch (SEP31BadRequestException $e) {
+            $this->assertEquals('invalid callback url', $e->getMessage());
+            $this->assertEquals(400, $e->getCode());
+        }
+    }
+
+    public function testPutTransactionCallbackWithServerError(): void {
+        $mock = new MockHandler([
+            new Response(500, [], json_encode(['error' => 'callback registration failed'])),
+        ]);
+
+        $httpClient = new Client(['handler' => HandlerStack::create($mock)]);
+        $service = new CrossBorderPaymentsService($this->serviceAddress, $httpClient);
+
+        try {
+            $service->putTransactionCallback(
+                '82fhs729f63dh0v4',
+                'https://sendinganchor.com/statusCallback',
+                $this->jwtToken
+            );
+            $this->fail('Expected SEP31UnknownResponseException was not thrown');
+        } catch (SEP31UnknownResponseException $e) {
+            $this->assertEquals('callback registration failed', $e->getMessage());
+            $this->assertEquals(500, $e->getCode());
+        }
+    }
+
+    public function testPutTransactionCallbackRejectsHttpCallbackUrl(): void {
+        $mock = new MockHandler([]);
+        $httpClient = new Client(['handler' => HandlerStack::create($mock)]);
+        $service = new CrossBorderPaymentsService($this->serviceAddress, $httpClient);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Service URL must use HTTPS');
+        $service->putTransactionCallback(
+            '82fhs729f63dh0v4',
+            'http://sendinganchor.com/statusCallback',
+            $this->jwtToken
+        );
+    }
+
+    public function testPatchTransactionWithServerError(): void {
+        $mock = new MockHandler([
+            new Response(500, [], json_encode(['error' => 'update failed'])),
+        ]);
+
+        $httpClient = new Client(['handler' => HandlerStack::create($mock)]);
+        $service = new CrossBorderPaymentsService($this->serviceAddress, $httpClient);
+
+        try {
+            $service->patchTransaction(
+                '82fhs729f63dh0v4',
+                ['transaction' => ['receiver_bank_account' => '12345678901234']],
+                $this->jwtToken
+            );
+            $this->fail('Expected SEP31UnknownResponseException was not thrown');
+        } catch (SEP31UnknownResponseException $e) {
+            $this->assertEquals('update failed', $e->getMessage());
+            $this->assertEquals(500, $e->getCode());
+        }
     }
 }

--- a/Soneso/StellarSDKTests/Unit/SEP/CrossBorderPayments/CrossBorderPaymentsTest.php
+++ b/Soneso/StellarSDKTests/Unit/SEP/CrossBorderPayments/CrossBorderPaymentsTest.php
@@ -623,4 +623,32 @@ class CrossBorderPaymentsTest extends TestCase
             $this->assertEquals(500, $e->getCode());
         }
     }
+
+    public function testPostTransactionsInfoNeededWithoutFields(): void {
+        // A transaction_info_needed error body without a fields key is valid;
+        // the typed exception is raised with null fields and no PHP warning.
+        $mock = new MockHandler([
+            new Response(400, [], json_encode(['error' => 'transaction_info_needed'])),
+        ]);
+
+        $httpClient = new Client(['handler' => HandlerStack::create($mock)]);
+        $service = new CrossBorderPaymentsService($this->serviceAddress, $httpClient);
+        $request = new SEP31PostTransactionsRequest(
+            amount: 100.0,
+            assetCode: 'USDC',
+        );
+
+        // Surface any warning (such as an undefined array key access) as a failure.
+        set_error_handler(static function (int $errno, string $errstr): bool {
+            throw new \ErrorException($errstr, 0, $errno);
+        });
+        try {
+            $service->postTransactions($request, $this->jwtToken);
+            $this->fail('Expected SEP31TransactionInfoNeededException was not thrown');
+        } catch (SEP31TransactionInfoNeededException $e) {
+            $this->assertNull($e->fields);
+        } finally {
+            restore_error_handler();
+        }
+    }
 }

--- a/Soneso/StellarSDKTests/Unit/SEP/Federation/FederationTest.php
+++ b/Soneso/StellarSDKTests/Unit/SEP/Federation/FederationTest.php
@@ -12,8 +12,10 @@ use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\Psr7\Response;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
+use Soneso\StellarSDK\Exceptions\HorizonRequestException;
 use Soneso\StellarSDK\SEP\Federation\Federation;
 use Soneso\StellarSDK\SEP\Federation\FederationRequestBuilder;
 
@@ -127,5 +129,94 @@ class FederationTest extends TestCase
         $this->assertEquals("text", $response->getMemoType());
         $this->assertEquals("hello memo text", $response->getMemo());
 
+    }
+
+    public function testResolveStellarAddressRejectsAddressWithoutSeparator(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Invalid federation address");
+        Federation::resolveStellarAddress("bobsoneso.com");
+    }
+
+    public function testResolveStellarAddressRejectsUnsafeDomain(): void
+    {
+        // The domain part is validated before any network request is made.
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Invalid domain");
+        Federation::resolveStellarAddress("bob*soneso.com/evil path");
+    }
+
+    public function testResolveStellarAccountIdNotFound(): void
+    {
+        $mock = new MockHandler([
+            new Response(404, [], "{\"detail\": \"not found\"}")
+        ]);
+
+        try {
+            Federation::resolveStellarAccountId(
+                "GBVPKXWMAB3FIUJB6T7LF66DABKKA2ZHRHDOQZ25GBAEFZVHTBPJNOJI",
+                "https://stellarid.io/federation",
+                httpClient: new Client(['handler' => HandlerStack::create($mock)])
+            );
+            $this->fail("Expected HorizonRequestException was not thrown");
+        } catch (HorizonRequestException $e) {
+            $this->assertEquals(404, $e->getStatusCode());
+        }
+    }
+
+    public function testResolveStellarAccountIdInvalidJsonResponse(): void
+    {
+        $mock = new MockHandler([
+            new Response(200, [], "not json {{{")
+        ]);
+
+        try {
+            Federation::resolveStellarAccountId(
+                "GBVPKXWMAB3FIUJB6T7LF66DABKKA2ZHRHDOQZ25GBAEFZVHTBPJNOJI",
+                "https://stellarid.io/federation",
+                httpClient: new Client(['handler' => HandlerStack::create($mock)])
+            );
+            $this->fail("Expected HorizonRequestException was not thrown");
+        } catch (HorizonRequestException $e) {
+            $this->assertStringContainsString("Error in json_decode", $e->getMessage());
+        }
+    }
+
+    public function testResolveStellarTransactionIdServerError(): void
+    {
+        $mock = new MockHandler([
+            new Response(500, [], "internal server error")
+        ]);
+
+        try {
+            Federation::resolveStellarTransactionId(
+                txId: "ae05181b239bd4a64ba2fb8086901479a0bde86f8e912150e74241fe4f5f0948",
+                federationServerUrl: "https://fedtest.io/federation",
+                httpClient: new Client(['handler' => HandlerStack::create($mock)])
+            );
+            $this->fail("Expected HorizonRequestException was not thrown");
+        } catch (HorizonRequestException $e) {
+            $this->assertEquals(500, $e->getStatusCode());
+        }
+    }
+
+    public function testResolveStellarAccountIdRejectsHttpServerUrl(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Service URL must use HTTPS");
+        Federation::resolveStellarAccountId(
+            "GBVPKXWMAB3FIUJB6T7LF66DABKKA2ZHRHDOQZ25GBAEFZVHTBPJNOJI",
+            "http://stellarid.io/federation"
+        );
+    }
+
+    public function testResolveForwardRejectsHttpServerUrl(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Service URL must use HTTPS");
+        Federation::resolveForward(
+            ["forward_type" => "bank_account", "swift" => "BOPBPHMM", "acct" => "2382376"],
+            "http://fedtest.io/federation"
+        );
     }
 }

--- a/Soneso/StellarSDKTests/Unit/SEP/Federation/FederationTest.php
+++ b/Soneso/StellarSDKTests/Unit/SEP/Federation/FederationTest.php
@@ -219,4 +219,39 @@ class FederationTest extends TestCase
             "http://fedtest.io/federation"
         );
     }
+
+    public function testResolveStellarAddressFullFlowWithInjectedClient(): void
+    {
+        // The injected client serves both requests: the stellar.toml fetch that
+        // resolves the federation server, and the federation query itself.
+        $toml = "FEDERATION_SERVER=\"https://stellarid.io/federation\"\n";
+        $mock = new MockHandler([
+            new Response(200, [], $toml),
+            new Response(200, [], $this->successResponse()),
+        ]);
+        $client = new Client(['handler' => HandlerStack::create($mock)]);
+
+        $response = Federation::resolveStellarAddress("bob*soneso.com", $client);
+
+        $this->assertEquals("bob*soneso.com", $response->getStellarAddress());
+        $this->assertEquals("GBVPKXWMAB3FIUJB6T7LF66DABKKA2ZHRHDOQZ25GBAEFZVHTBPJNOJI", $response->getAccountId());
+        $this->assertSame(0, $mock->count());
+    }
+
+    public function testResolveStellarAddressWithoutFederationServerInToml(): void
+    {
+        $toml = "SIGNING_KEY=\"GBVPKXWMAB3FIUJB6T7LF66DABKKA2ZHRHDOQZ25GBAEFZVHTBPJNOJI\"\n";
+        $mock = new MockHandler([
+            new Response(200, [], $toml),
+        ]);
+        $client = new Client(['handler' => HandlerStack::create($mock)]);
+
+        $exception = false;
+        try {
+            Federation::resolveStellarAddress("bob*soneso.com", $client);
+        } catch (Exception $e) {
+            $exception = str_contains($e->getMessage(), 'no federation server found');
+        }
+        $this->assertTrue($exception);
+    }
 }

--- a/Soneso/StellarSDKTests/Unit/SEP/Toml/StellarTomlFromDomainTest.php
+++ b/Soneso/StellarSDKTests/Unit/SEP/Toml/StellarTomlFromDomainTest.php
@@ -1,0 +1,143 @@
+<?php declare(strict_types=1);
+
+// Copyright 2026 The Stellar PHP SDK Authors. All rights reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+namespace Soneso\StellarSDKTests\Unit\SEP\Toml;
+
+use Exception;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+use Soneso\StellarSDK\SEP\Toml\StellarToml;
+use Yosymfony\Toml\Exception\ParseException;
+
+class StellarTomlFromDomainTest extends TestCase
+{
+    private string $tomlBody = 'VERSION="2.0.0"
+NETWORK_PASSPHRASE="Public Global Stellar Network ; September 2015"
+FEDERATION_SERVER="https://federation.example.com"
+SIGNING_KEY="GBBHQ7H4V6RRORKYLHTCAWP6MOHNORRFJSDPXDFYDGJB2LPZUFPXUEW3"
+DIRECT_PAYMENT_SERVER="https://payments.example.com"
+
+[[CURRENCIES]]
+code="USD"
+issuer="GCZJM35NKGVK47BB4SPBDV25477PZYIYPVVG453LPYFNXLS3FGHDXOCM"
+display_decimals=2';
+
+    public function testFromDomainSuccess(): void
+    {
+        $mock = new MockHandler([
+            new Response(200, [], $this->tomlBody)
+        ]);
+
+        $stack = new HandlerStack();
+        $stack->setHandler($mock);
+        $stack->push(Middleware::mapRequest(function (RequestInterface $request) {
+            $this->assertEquals("GET", $request->getMethod());
+            $this->assertEquals(
+                "https://example.com/.well-known/stellar.toml",
+                (string)$request->getUri()
+            );
+            return $request;
+        }));
+
+        $stellarToml = StellarToml::fromDomain("example.com", new Client(['handler' => $stack]));
+
+        $generalInformation = $stellarToml->getGeneralInformation();
+        $this->assertNotNull($generalInformation);
+        $this->assertEquals("2.0.0", $generalInformation->version);
+        $this->assertEquals(
+            "Public Global Stellar Network ; September 2015",
+            $generalInformation->networkPassphrase
+        );
+        $this->assertEquals("https://federation.example.com", $generalInformation->federationServer);
+        $this->assertEquals(
+            "GBBHQ7H4V6RRORKYLHTCAWP6MOHNORRFJSDPXDFYDGJB2LPZUFPXUEW3",
+            $generalInformation->signingKey
+        );
+        $this->assertEquals("https://payments.example.com", $generalInformation->directPaymentServer);
+
+        $currencies = $stellarToml->getCurrencies()->toArray();
+        $this->assertCount(1, $currencies);
+        $this->assertEquals("USD", $currencies[0]->code);
+        $this->assertEquals(
+            "GCZJM35NKGVK47BB4SPBDV25477PZYIYPVVG453LPYFNXLS3FGHDXOCM",
+            $currencies[0]->issuer
+        );
+        $this->assertEquals(2, $currencies[0]->displayDecimals);
+    }
+
+    public function testFromDomainNotFound(): void
+    {
+        $mock = new MockHandler([
+            new Response(404, [], "not found")
+        ]);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage("Stellar toml not found.");
+        StellarToml::fromDomain("example.com", new Client(['handler' => HandlerStack::create($mock)]));
+    }
+
+    public function testFromDomainNon200StatusCode(): void
+    {
+        // With http_errors disabled the client returns the response so that
+        // the explicit status code check in fromDomain throws.
+        $mock = new MockHandler([
+            new Response(500, [], "internal server error")
+        ]);
+        $client = new Client(['handler' => HandlerStack::create($mock), 'http_errors' => false]);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage("Stellar toml not found. Response status code 500");
+        StellarToml::fromDomain("example.com", $client);
+    }
+
+    public function testFromDomainServerError(): void
+    {
+        $mock = new MockHandler([
+            new Response(500, [], "internal server error")
+        ]);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage("Stellar toml not found.");
+        StellarToml::fromDomain("example.com", new Client(['handler' => HandlerStack::create($mock)]));
+    }
+
+    public function testFromDomainMalformedToml(): void
+    {
+        $mock = new MockHandler([
+            new Response(200, [], "this is = not [ valid toml ===")
+        ]);
+
+        $this->expectException(ParseException::class);
+        StellarToml::fromDomain("example.com", new Client(['handler' => HandlerStack::create($mock)]));
+    }
+
+    public function testFromDomainRejectsDomainWithPath(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Invalid domain");
+        StellarToml::fromDomain("example.com/.well-known/../evil");
+    }
+
+    public function testFromDomainRejectsDomainWithWhitespace(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Invalid domain");
+        StellarToml::fromDomain("exa mple.com");
+    }
+
+    public function testCurrencyFromUrlRejectsHttpUrl(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Service URL must use HTTPS");
+        StellarToml::currencyFromUrl("http://example.com/.well-known/USD.toml");
+    }
+}

--- a/Soneso/StellarSDKTests/Unit/SEP/Toml/StellarTomlFromDomainTest.php
+++ b/Soneso/StellarSDKTests/Unit/SEP/Toml/StellarTomlFromDomainTest.php
@@ -140,4 +140,51 @@ display_decimals=2';
         $this->expectExceptionMessage("Service URL must use HTTPS");
         StellarToml::currencyFromUrl("http://example.com/.well-known/USD.toml");
     }
+
+    public function testCurrencyFromUrlSuccess(): void
+    {
+        $currencyToml = 'code = "USD"' . "\n"
+            . 'issuer = "GAKL4XMWLXQKYNYR6ZDVLZT5FXQK3PKC4GZW7OKJX4KQLJKRWBWDXNYK"' . "\n"
+            . 'display_decimals = 2' . "\n"
+            . 'name = "US Dollar"' . "\n";
+        $mock = new MockHandler([
+            new Response(200, [], $currencyToml),
+        ]);
+        $client = new Client(['handler' => HandlerStack::create($mock)]);
+
+        $currency = StellarToml::currencyFromUrl("https://example.com/.well-known/USD.toml", $client);
+
+        $this->assertEquals("USD", $currency->code);
+        $this->assertEquals("GAKL4XMWLXQKYNYR6ZDVLZT5FXQK3PKC4GZW7OKJX4KQLJKRWBWDXNYK", $currency->issuer);
+        $this->assertEquals(2, $currency->displayDecimals);
+        $this->assertEquals("US Dollar", $currency->name);
+        $this->assertSame(0, $mock->count());
+    }
+
+    public function testCurrencyFromUrlNotFound(): void
+    {
+        $mock = new MockHandler([
+            new Response(404, [], 'not found'),
+        ]);
+        $client = new Client(['handler' => HandlerStack::create($mock)]);
+
+        $exception = false;
+        try {
+            StellarToml::currencyFromUrl("https://example.com/.well-known/USD.toml", $client);
+        } catch (Exception $e) {
+            $exception = str_contains($e->getMessage(), 'Currency toml not found');
+        }
+        $this->assertTrue($exception);
+    }
+
+    public function testCurrencyFromUrlMalformedToml(): void
+    {
+        $mock = new MockHandler([
+            new Response(200, [], 'this is = not [ valid toml ==='),
+        ]);
+        $client = new Client(['handler' => HandlerStack::create($mock)]);
+
+        $this->expectException(ParseException::class);
+        StellarToml::currencyFromUrl("https://example.com/.well-known/USD.toml", $client);
+    }
 }

--- a/Soneso/StellarSDKTests/Unit/SEP/URIScheme/URISchemeTest.php
+++ b/Soneso/StellarSDKTests/Unit/SEP/URIScheme/URISchemeTest.php
@@ -452,6 +452,101 @@ class URISchemeTest extends TestCase
         $this->assertTrue($result);
     }
 
+    public function testCheckURISchemeIsValidWithSpecialCharacterSignature(): void
+    {
+        // The SEP-7 spec test vector produces a signature containing base64
+        // '+', '/' and '==' characters, which must survive URL-encoding during
+        // verification. The payload is reconstructed by stripping at the
+        // "&signature=" marker, independent of the signature value's encoding.
+        $uriScheme = new URIScheme();
+        $signer = KeyPair::fromSeed('SBPOVRVKTTV7W3IOX2FJPSMPCJ5L2WU2YKTP3HCLYPXNI5MDIGREVNYC');
+        $uri = 'web+stellar:pay?destination=GCALNQQBXAPZ2WIRSDDBMSTAKCUH5SG6U76YBFLQLIXJTF7FE5AX7AOO'
+            . '&amount=120.1234567&memo=skdjfasf&memo_type=MEMO_TEXT'
+            . '&msg=pay%20me%20with%20lumens&origin_domain=someDomain.com';
+        $signedUri = $uriScheme->signURI($uri, $signer);
+        // Sanity: the signature value is URL-encoded (contains %2F for '/').
+        $this->assertStringContainsString('&signature=', $signedUri);
+        $this->assertStringContainsString('%2F', $signedUri);
+
+        $tomlContent = "URI_REQUEST_SIGNING_KEY = \"" . $signer->getAccountId() . "\"\n";
+        $mock = new MockHandler([
+            new Response(200, [], $tomlContent)
+        ]);
+        $uriScheme->setMockHandlerStack(HandlerStack::create($mock));
+
+        $this->assertTrue($uriScheme->checkUIRSchemeIsValid($signedUri));
+    }
+
+    public function testCheckURISchemeRejectsTamperedUri(): void
+    {
+        $uriScheme = new URIScheme();
+        $signer = KeyPair::fromSeed(self::TEST_SECRET);
+        $uri = $uriScheme->generateSignTransactionURI(self::TEST_XDR, originDomain: 'example.com');
+        $signedUri = $uriScheme->signURI($uri, $signer);
+
+        // Tamper with the payload after signing: the signature must no longer verify.
+        $tamperedUri = str_replace('origin_domain=example.com', 'origin_domain=evil.com', $signedUri);
+
+        $tomlContent = "URI_REQUEST_SIGNING_KEY = \"" . self::TEST_SIGNER_ACCOUNT . "\"\n";
+        $mock = new MockHandler([
+            new Response(200, [], $tomlContent)
+        ]);
+        $uriScheme->setMockHandlerStack(HandlerStack::create($mock));
+
+        $exception = false;
+        try {
+            $uriScheme->checkUIRSchemeIsValid($tamperedUri);
+        } catch (URISchemeError $e) {
+            $exception = ($e->getCode() === URISchemeError::invalidSignature);
+        }
+        $this->assertTrue($exception);
+    }
+
+    public function testCheckURISchemeRejectsInvalidBase64Signature(): void
+    {
+        $uriScheme = new URIScheme();
+        // The signature value is not valid base64.
+        $uri = $uriScheme->generateSignTransactionURI(
+            self::TEST_XDR,
+            originDomain: 'example.com',
+            signature: '@@@invalid@@@'
+        );
+
+        $tomlContent = "URI_REQUEST_SIGNING_KEY = \"" . self::TEST_SIGNER_ACCOUNT . "\"\n";
+        $mock = new MockHandler([
+            new Response(200, [], $tomlContent)
+        ]);
+        $uriScheme->setMockHandlerStack(HandlerStack::create($mock));
+
+        $exception = false;
+        try {
+            $uriScheme->checkUIRSchemeIsValid($uri);
+        } catch (URISchemeError $e) {
+            $exception = ($e->getCode() === URISchemeError::invalidSignature);
+        }
+        $this->assertTrue($exception);
+    }
+
+    public function testCheckURISchemeIsValidForSignedPayUri(): void
+    {
+        $uriScheme = new URIScheme();
+        $signer = KeyPair::fromSeed(self::TEST_SECRET);
+        $uri = $uriScheme->generatePayOperationURI(
+            self::TEST_DESTINATION,
+            amount: '10',
+            originDomain: 'example.com'
+        );
+        $signedUri = $uriScheme->signURI($uri, $signer);
+
+        $tomlContent = "URI_REQUEST_SIGNING_KEY = \"" . self::TEST_SIGNER_ACCOUNT . "\"\n";
+        $mock = new MockHandler([
+            new Response(200, [], $tomlContent)
+        ]);
+        $uriScheme->setMockHandlerStack(HandlerStack::create($mock));
+
+        $this->assertTrue($uriScheme->checkUIRSchemeIsValid($signedUri));
+    }
+
     // ==================== setMockHandlerStack Tests ====================
 
     public function testSetMockHandlerStack(): void

--- a/Soneso/StellarSDKTests/Unit/SEP/WebAuth/WebAuthTest.php
+++ b/Soneso/StellarSDKTests/Unit/SEP/WebAuth/WebAuthTest.php
@@ -226,6 +226,33 @@ class WebAuthTest extends TestCase
         return json_encode(['transaction' => $transaction->toEnvelopeXdrBase64()]);
     }
 
+    private function requestChallengeMissingTimeBounds(string $accountId) : string {
+        $transactionAccount = new Account($this->serverAccountId, new BigInteger(-1));
+        $transaction = (new TransactionBuilder($transactionAccount))
+            ->addOperation($this::validFirstManageDataOp($accountId))
+            ->addOperation($this::validSecondManageDataOp())
+            ->addMemo(Memo::none())
+            ->build();
+        $transaction->sign($this->serverKeyPair, Network::testnet());
+        return json_encode(['transaction' => $transaction->toEnvelopeXdrBase64()]);
+    }
+
+    private function infiniteTimeBounds() : TimeBounds {
+        return new TimeBounds((new DateTime)->setTimestamp(time()), (new DateTime)->setTimestamp(0));
+    }
+
+    private function requestChallengeInfiniteTimeBounds(string $accountId) : string {
+        $transactionAccount = new Account($this->serverAccountId, new BigInteger(-1));
+        $transaction = (new TransactionBuilder($transactionAccount))
+            ->addOperation($this::validFirstManageDataOp($accountId))
+            ->addOperation($this::validSecondManageDataOp())
+            ->addMemo(Memo::none())
+            ->setTimeBounds($this::infiniteTimeBounds())
+            ->build();
+        $transaction->sign($this->serverKeyPair, Network::testnet());
+        return json_encode(['transaction' => $transaction->toEnvelopeXdrBase64()]);
+    }
+
     private function requestChallengeInvalidOperationType(string $accountId) : string {
         $transactionAccount = new Account($this->serverAccountId, new BigInteger(-1));
         $transaction = (new TransactionBuilder($transactionAccount))
@@ -510,6 +537,46 @@ class WebAuthTest extends TestCase
         $webAuth = new WebAuth($this->authServer, $this->serverAccountId, $this->domain, Network::testnet());
         $mock = new MockHandler([
             new Response(200, ['X-Foo' => 'Bar'], $this->requestChallengeInvalidTimeBounds($this->clientAccountId))
+        ]);
+        $webAuth->setMockHandler($mock);
+        $userKeyPair = KeyPair::fromSeed($this->clientSecretSeed);
+        $userAccountId = $userKeyPair->getAccountId();
+        $exception = false;
+        try {
+            $jwtToken = $webAuth->jwtToken($userAccountId, [$userKeyPair]);
+        } catch (GuzzleException $e) {
+        } catch (ErrorException $e) {
+            if ($e instanceof ChallengeValidationErrorInvalidTimeBounds) {
+                $exception = true;
+            }
+        }
+        $this->assertTrue($exception);
+    }
+
+    public function testGetChallengeMissingTimeBounds(): void {
+        $webAuth = new WebAuth($this->authServer, $this->serverAccountId, $this->domain, Network::testnet());
+        $mock = new MockHandler([
+            new Response(200, ['X-Foo' => 'Bar'], $this->requestChallengeMissingTimeBounds($this->clientAccountId))
+        ]);
+        $webAuth->setMockHandler($mock);
+        $userKeyPair = KeyPair::fromSeed($this->clientSecretSeed);
+        $userAccountId = $userKeyPair->getAccountId();
+        $exception = false;
+        try {
+            $jwtToken = $webAuth->jwtToken($userAccountId, [$userKeyPair]);
+        } catch (GuzzleException $e) {
+        } catch (ErrorException $e) {
+            if ($e instanceof ChallengeValidationErrorInvalidTimeBounds) {
+                $exception = true;
+            }
+        }
+        $this->assertTrue($exception);
+    }
+
+    public function testGetChallengeInfiniteTimeBounds(): void {
+        $webAuth = new WebAuth($this->authServer, $this->serverAccountId, $this->domain, Network::testnet());
+        $mock = new MockHandler([
+            new Response(200, ['X-Foo' => 'Bar'], $this->requestChallengeInfiniteTimeBounds($this->clientAccountId))
         ]);
         $webAuth->setMockHandler($mock);
         $userKeyPair = KeyPair::fromSeed($this->clientSecretSeed);

--- a/Soneso/StellarSDKTests/Unit/SEP/WebAuth/WebAuthTest.php
+++ b/Soneso/StellarSDKTests/Unit/SEP/WebAuth/WebAuthTest.php
@@ -12,6 +12,7 @@ use Exception;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
 use InvalidArgumentException;
 use phpseclib3\Math\BigInteger;
 use PHPUnit\Framework\TestCase;
@@ -36,6 +37,9 @@ use Soneso\StellarSDK\SEP\WebAuth\ChallengeValidationErrorInvalidSignature;
 use Soneso\StellarSDK\SEP\WebAuth\ChallengeValidationErrorInvalidSourceAccount;
 use Soneso\StellarSDK\SEP\WebAuth\ChallengeValidationErrorInvalidTimeBounds;
 use Soneso\StellarSDK\SEP\WebAuth\ChallengeValidationErrorInvalidWebAuthDomain;
+use Soneso\StellarSDK\SEP\WebAuth\SubmitCompletedChallengeErrorResponseException;
+use Soneso\StellarSDK\SEP\WebAuth\SubmitCompletedChallengeTimeoutResponseException;
+use Soneso\StellarSDK\SEP\WebAuth\SubmitCompletedChallengeUnknownResponseException;
 use Soneso\StellarSDK\SEP\WebAuth\WebAuth;
 use Soneso\StellarSDK\TimeBounds;
 use Soneso\StellarSDK\TransactionBuilder;
@@ -323,6 +327,10 @@ class WebAuthTest extends TestCase
         return json_encode(['token' => $this->successJWTToken]);
     }
 
+    private function requestJWTError() : string{
+        return json_encode(['error' => 'The provided transaction is not valid']);
+    }
+
     public function testDefaultSuccess(): void {
         $webAuth = new WebAuth($this->authServer, $this->serverAccountId, $this->domain, Network::testnet());
         $mock = new MockHandler([
@@ -587,6 +595,196 @@ class WebAuthTest extends TestCase
         } catch (GuzzleException $e) {
         } catch (ErrorException $e) {
             if ($e instanceof ChallengeValidationErrorInvalidTimeBounds) {
+                $exception = true;
+            }
+        }
+        $this->assertTrue($exception);
+    }
+
+    public function testMemoWithMuxedAccountRejected(): void {
+        $webAuth = new WebAuth($this->authServer, $this->serverAccountId, $this->domain, Network::testnet());
+        $userKeyPair = KeyPair::fromSeed($this->clientSecretSeed);
+        $exception = false;
+        try {
+            $webAuth->jwtToken($this->clientAccountIdM, [$userKeyPair], $this->testMemo);
+        } catch (GuzzleException $e) {
+        } catch (InvalidArgumentException $e) {
+            $exception = true;
+        }
+        $this->assertTrue($exception);
+    }
+
+    public function testGetChallengeInvalidBase64(): void {
+        $webAuth = new WebAuth($this->authServer, $this->serverAccountId, $this->domain, Network::testnet());
+        $mock = new MockHandler([
+            new Response(200, ['X-Foo' => 'Bar'], json_encode(['transaction' => '@@@not-valid-base64@@@']))
+        ]);
+        $webAuth->setMockHandler($mock);
+        $userKeyPair = KeyPair::fromSeed($this->clientSecretSeed);
+        $userAccountId = $userKeyPair->getAccountId();
+        $exception = false;
+        try {
+            $jwtToken = $webAuth->jwtToken($userAccountId, [$userKeyPair]);
+        } catch (GuzzleException $e) {
+        } catch (InvalidArgumentException $e) {
+            $exception = true;
+        }
+        $this->assertTrue($exception);
+    }
+
+    public function testGetChallengeMissingMemo(): void {
+        $webAuth = new WebAuth($this->authServer, $this->serverAccountId, $this->domain, Network::testnet());
+        $mock = new MockHandler([
+            new Response(200, ['X-Foo' => 'Bar'], $this->requestChallengeSuccess($this->clientAccountId))
+        ]);
+        $webAuth->setMockHandler($mock);
+        $userKeyPair = KeyPair::fromSeed($this->clientSecretSeed);
+        $userAccountId = $userKeyPair->getAccountId();
+        $exception = false;
+        try {
+            $jwtToken = $webAuth->jwtToken($userAccountId, [$userKeyPair], $this->testMemo);
+        } catch (GuzzleException $e) {
+        } catch (ErrorException $e) {
+            if ($e instanceof ChallengeValidationErrorInvalidMemoValue) {
+                $exception = true;
+            }
+        }
+        $this->assertTrue($exception);
+    }
+
+    public function testSubmitChallengeErrorResponse(): void {
+        $webAuth = new WebAuth($this->authServer, $this->serverAccountId, $this->domain, Network::testnet());
+        $mock = new MockHandler([
+            new Response(200, ['X-Foo' => 'Bar'], $this->requestChallengeSuccess($this->clientAccountId, 200)),
+            new Response(400, ['X-Foo' => 'Bar'], $this->requestJWTError())
+        ]);
+        $webAuth->setMockHandler($mock);
+        $userKeyPair = KeyPair::fromSeed($this->clientSecretSeed);
+        $userAccountId = $userKeyPair->getAccountId();
+        $exception = false;
+        try {
+            $jwtToken = $webAuth->jwtToken($userAccountId, [$userKeyPair]);
+        } catch (GuzzleException $e) {
+        } catch (ErrorException $e) {
+            if ($e instanceof SubmitCompletedChallengeErrorResponseException) {
+                $exception = true;
+            }
+        }
+        $this->assertTrue($exception);
+    }
+
+    public function testSubmitChallengeMalformedJson(): void {
+        $webAuth = new WebAuth($this->authServer, $this->serverAccountId, $this->domain, Network::testnet());
+        $mock = new MockHandler([
+            new Response(200, ['X-Foo' => 'Bar'], $this->requestChallengeSuccess($this->clientAccountId, 200)),
+            new Response(200, ['X-Foo' => 'Bar'], '{not valid json')
+        ]);
+        $webAuth->setMockHandler($mock);
+        $userKeyPair = KeyPair::fromSeed($this->clientSecretSeed);
+        $userAccountId = $userKeyPair->getAccountId();
+        $exception = false;
+        try {
+            $jwtToken = $webAuth->jwtToken($userAccountId, [$userKeyPair]);
+        } catch (GuzzleException $e) {
+        } catch (ErrorException $e) {
+            if ($e instanceof SubmitCompletedChallengeErrorResponseException) {
+                $exception = true;
+            }
+        }
+        $this->assertTrue($exception);
+    }
+
+    public function testSubmitChallengeNoTokenNoError(): void {
+        $webAuth = new WebAuth($this->authServer, $this->serverAccountId, $this->domain, Network::testnet());
+        $mock = new MockHandler([
+            new Response(200, ['X-Foo' => 'Bar'], $this->requestChallengeSuccess($this->clientAccountId, 200)),
+            new Response(200, ['X-Foo' => 'Bar'], json_encode(['unexpected' => 'value']))
+        ]);
+        $webAuth->setMockHandler($mock);
+        $userKeyPair = KeyPair::fromSeed($this->clientSecretSeed);
+        $userAccountId = $userKeyPair->getAccountId();
+        $exception = false;
+        try {
+            $jwtToken = $webAuth->jwtToken($userAccountId, [$userKeyPair]);
+        } catch (GuzzleException $e) {
+        } catch (ErrorException $e) {
+            if ($e instanceof SubmitCompletedChallengeErrorResponseException) {
+                $exception = true;
+            }
+        }
+        $this->assertTrue($exception);
+    }
+
+    public function testSubmitChallengeTimeout(): void {
+        $webAuth = new WebAuth($this->authServer, $this->serverAccountId, $this->domain, Network::testnet());
+        $mock = new MockHandler([
+            new Response(200, ['X-Foo' => 'Bar'], $this->requestChallengeSuccess($this->clientAccountId, 200)),
+            new Response(504, ['X-Foo' => 'Bar'], '')
+        ]);
+        $webAuth->setMockHandler($mock);
+        $userKeyPair = KeyPair::fromSeed($this->clientSecretSeed);
+        $userAccountId = $userKeyPair->getAccountId();
+        $exception = false;
+        try {
+            $jwtToken = $webAuth->jwtToken($userAccountId, [$userKeyPair]);
+        } catch (GuzzleException $e) {
+        } catch (ErrorException $e) {
+            if ($e instanceof SubmitCompletedChallengeTimeoutResponseException) {
+                $exception = true;
+            }
+        }
+        $this->assertTrue($exception);
+    }
+
+    public function testSubmitChallengeUnknownResponse(): void {
+        $webAuth = new WebAuth($this->authServer, $this->serverAccountId, $this->domain, Network::testnet());
+        $mock = new MockHandler([
+            new Response(200, ['X-Foo' => 'Bar'], $this->requestChallengeSuccess($this->clientAccountId, 200)),
+            new Response(503, ['X-Foo' => 'Bar'], 'service unavailable')
+        ]);
+        $webAuth->setMockHandler($mock);
+        $userKeyPair = KeyPair::fromSeed($this->clientSecretSeed);
+        $userAccountId = $userKeyPair->getAccountId();
+        $exception = false;
+        try {
+            $jwtToken = $webAuth->jwtToken($userAccountId, [$userKeyPair]);
+        } catch (GuzzleException $e) {
+        } catch (ErrorException $e) {
+            if ($e instanceof SubmitCompletedChallengeUnknownResponseException) {
+                $exception = true;
+            }
+        }
+        $this->assertTrue($exception);
+    }
+
+    public function testFromDomainMissingWebAuthEndpoint(): void {
+        $toml = 'SIGNING_KEY="' . $this->serverAccountId . '"';
+        $client = new Client(['handler' => HandlerStack::create(new MockHandler([
+            new Response(200, [], $toml)
+        ]))]);
+        $exception = false;
+        try {
+            WebAuth::fromDomain('place.domain.com', Network::testnet(), $client);
+        } catch (GuzzleException $e) {
+        } catch (Exception $e) {
+            if (str_contains($e->getMessage(), 'WEB_AUTH_ENDPOINT')) {
+                $exception = true;
+            }
+        }
+        $this->assertTrue($exception);
+    }
+
+    public function testFromDomainMissingSigningKey(): void {
+        $toml = 'WEB_AUTH_ENDPOINT="https://auth.place.domain.com/auth"';
+        $client = new Client(['handler' => HandlerStack::create(new MockHandler([
+            new Response(200, [], $toml)
+        ]))]);
+        $exception = false;
+        try {
+            WebAuth::fromDomain('place.domain.com', Network::testnet(), $client);
+        } catch (GuzzleException $e) {
+        } catch (Exception $e) {
+            if (str_contains($e->getMessage(), 'SIGNING_KEY')) {
                 $exception = true;
             }
         }

--- a/Soneso/StellarSDKTests/Unit/SEP/WebAuth/WebAuthTest.php
+++ b/Soneso/StellarSDKTests/Unit/SEP/WebAuth/WebAuthTest.php
@@ -885,59 +885,6 @@ class WebAuthTest extends TestCase
         $this->assertEquals($this->successJWTToken, $jwtToken);
     }
 
-    /**
-     * Integration test: SEP-10 authentication with testanchor.stellar.org
-     */
-    public function testWithStellarTestAnchor(): void {
-        $webAuth = WebAuth::fromDomain("testanchor.stellar.org", Network::testnet());
-
-        $userKeyPair = KeyPair::random();
-        $userAccountId = $userKeyPair->getAccountId();
-        $jwt = $webAuth->jwtToken($userAccountId, [$userKeyPair]);
-        $this->assertNotEmpty($jwt);
-    }
-
-    /**
-     * Integration test: SEP-10 authentication with testanchor.stellar.org and client domain
-     *
-     * Uses phpsepsigner.stellargate.com as the client domain signing server.
-     *
-     * @see https://github.com/Soneso/php-server-signer
-     */
-    public function testWithStellarTestAnchorAndClientDomain(): void {
-        $webAuth = WebAuth::fromDomain("testanchor.stellar.org", Network::testnet());
-
-        $clientDomain = "phpsepsigner.stellargate.com";
-        $bearerToken = "103e1e6234ac2cc1a30d983dba367db2b194ea5b269433c316ad36d21e1e8235";
-
-        $callback = function (string $b64EncodedEnvelope) use ($bearerToken) {
-            $httpClient = new Client();
-            $response = $httpClient->request('POST', 'https://phpsepsigner.stellargate.com/sign-sep-10', [
-                'json' => [
-                    'transaction' => $b64EncodedEnvelope,
-                    'network_passphrase' => 'Test SDF Network ; September 2015'
-                ],
-                'headers' => ['Authorization' => 'Bearer ' . $bearerToken]
-            ]);
-            $content = $response->getBody()->__toString();
-            $jsonData = json_decode($content, true);
-            if (isset($jsonData['transaction'])) {
-                return $jsonData['transaction'];
-            }
-            throw new Exception("Invalid server response: " . $content);
-        };
-
-        $userKeyPair = KeyPair::random();
-        $userAccountId = $userKeyPair->getAccountId();
-        $jwt = $webAuth->jwtToken(
-            $userAccountId,
-            [$userKeyPair],
-            clientDomain: $clientDomain,
-            clientDomainSigningCallback: $callback
-        );
-        $this->assertNotEmpty($jwt);
-    }
-
     // Edge Case Tests - Token Expiration and Challenge Validation
 
     public function testChallengeExpirationAtLowerBound(): void

--- a/Soneso/StellarSDKTests/Unit/Soroban/AssembledTransactionTest.php
+++ b/Soneso/StellarSDKTests/Unit/Soroban/AssembledTransactionTest.php
@@ -54,7 +54,10 @@ class AssembledTransactionTest extends TestCase
 {
     private const TEST_ACCOUNT_ID = "GD56FXQWEQ34GBKJLU52QD3YB4CJSJCVPLOKISGZDRCYVIWZK5TMVDT3";
     private const TEST_CONTRACT_ID = "CA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUWDA";
-    private const TEST_RPC_URL = "https://soroban-testnet.stellar.org:443";
+    // Unroutable on purpose: all HTTP is served by injected mock handlers, and
+    // if a test ever issues an unmocked request it errors out locally instead
+    // of reaching a live server.
+    private const TEST_RPC_URL = "http://localhost:1";
 
     // Test account secret key for signing tests - corresponds to TEST_ACCOUNT_ID
     private const TEST_SECRET_KEY = "SAMKI63THJER2XVJA5LQXIPBWIV6FEFSS5ILURYGSCHFKZVDE5YVQWC7";
@@ -91,6 +94,41 @@ class AssembledTransactionTest extends TestCase
                         'xdr' => XdrSCVal::forVoid()->toBase64Xdr()
                     ]
                 ]
+            ]
+        ]));
+    }
+
+    /**
+     * Creates a mock HTTP response for sendTransaction with PENDING status.
+     */
+    private function createSendTransactionResponse(): Response
+    {
+        return new Response(200, [], json_encode([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'result' => [
+                'status' => 'PENDING',
+                'hash' => str_repeat('ab', 32),
+                'latestLedger' => 1000,
+                'latestLedgerCloseTime' => '1700000000',
+            ]
+        ]));
+    }
+
+    /**
+     * Creates a mock HTTP response for getTransaction with SUCCESS status.
+     */
+    private function createGetTransactionSuccessResponse(): Response
+    {
+        return new Response(200, [], json_encode([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'result' => [
+                'status' => GetTransactionResponse::STATUS_SUCCESS,
+                'latestLedger' => 1001,
+                'latestLedgerCloseTime' => '1700000001',
+                'oldestLedger' => 990,
+                'oldestLedgerCloseTime' => '1699999000',
             ]
         ]));
     }
@@ -148,8 +186,10 @@ class AssembledTransactionTest extends TestCase
 
     /**
      * Injects a mocked HTTP client into an AssembledTransaction's server.
+     *
+     * Returns the mock handler so tests can assert the queue was fully consumed.
      */
-    private function injectMockedServer(AssembledTransaction $tx, array $responses): void
+    private function injectMockedServer(AssembledTransaction $tx, array $responses): MockHandler
     {
         $mock = new MockHandler($responses);
         $handlerStack = HandlerStack::create($mock);
@@ -164,6 +204,8 @@ class AssembledTransactionTest extends TestCase
         $httpClientProperty = $serverReflection->getProperty('httpClient');
         $httpClientProperty->setAccessible(true);
         $httpClientProperty->setValue($server, $client);
+
+        return $mock;
     }
 
     public function testAssembledTransactionOptionsConstruction(): void
@@ -789,10 +831,17 @@ class AssembledTransactionTest extends TestCase
         );
         $property->setValue($tx, $mockResult);
 
-        // This should throw because we haven't set up send mocks (connection refused)
-        $this->expectException(Exception::class);
+        $mock = $this->injectMockedServer($tx, [
+            $this->createSendTransactionResponse(),
+            $this->createGetTransactionSuccessResponse(),
+        ]);
 
-        $tx->signAndSend();
+        $response = $tx->signAndSend();
+
+        $this->assertSame(GetTransactionResponse::STATUS_SUCCESS, $response->status);
+        $this->assertNotNull($tx->signed);
+        $this->assertCount(1, $tx->signed->getSignatures());
+        $this->assertSame(0, $mock->count());
     }
 
     public function testIsReadOnlyReturnsFalseWithoutSimulation(): void

--- a/Soneso/StellarSDKTests/Unit/Soroban/SorobanClientTest.php
+++ b/Soneso/StellarSDKTests/Unit/Soroban/SorobanClientTest.php
@@ -1,0 +1,712 @@
+<?php declare(strict_types=1);
+
+// Copyright 2026 The Stellar PHP SDK Authors. All rights reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+namespace Soneso\StellarSDKTests\Unit\Soroban;
+
+use Exception;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use phpseclib3\Math\BigInteger;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionProperty;
+use Soneso\StellarSDK\Crypto\KeyPair;
+use Soneso\StellarSDK\InvokeContractHostFunction;
+use Soneso\StellarSDK\InvokeHostFunctionOperation;
+use Soneso\StellarSDK\Network;
+use Soneso\StellarSDK\Soroban\Contract\AssembledTransaction;
+use Soneso\StellarSDK\Soroban\Contract\ClientOptions;
+use Soneso\StellarSDK\Soroban\Contract\ContractSpec;
+use Soneso\StellarSDK\Soroban\Contract\DeployRequest;
+use Soneso\StellarSDK\Soroban\Contract\InstallRequest;
+use Soneso\StellarSDK\Soroban\Contract\MethodOptions;
+use Soneso\StellarSDK\Soroban\Contract\SorobanClient;
+use Soneso\StellarSDK\Soroban\Responses\GetTransactionResponse;
+use Soneso\StellarSDK\Soroban\Responses\SorobanRpcErrorResponse;
+use Soneso\StellarSDK\Soroban\SorobanServer;
+use Soneso\StellarSDK\Xdr\XdrAccountEntry;
+use Soneso\StellarSDK\Xdr\XdrAccountEntryExt;
+use Soneso\StellarSDK\Xdr\XdrAccountID;
+use Soneso\StellarSDK\Xdr\XdrExtensionPoint;
+use Soneso\StellarSDK\Xdr\XdrLedgerEntryData;
+use Soneso\StellarSDK\Xdr\XdrLedgerEntryType;
+use Soneso\StellarSDK\Xdr\XdrLedgerFootprint;
+use Soneso\StellarSDK\Xdr\XdrLedgerKey;
+use Soneso\StellarSDK\Xdr\XdrLedgerKeyAccount;
+use Soneso\StellarSDK\Xdr\XdrSCSpecEntry;
+use Soneso\StellarSDK\Xdr\XdrSCSpecEntryKind;
+use Soneso\StellarSDK\Xdr\XdrSCSpecFunctionV0;
+use Soneso\StellarSDK\Xdr\XdrSCSpecTypeDef;
+use Soneso\StellarSDK\Xdr\XdrSCSpecType;
+use Soneso\StellarSDK\Xdr\XdrSCSpecUDTStructV0;
+use Soneso\StellarSDK\Xdr\XdrSCVal;
+use Soneso\StellarSDK\Xdr\XdrSequenceNumber;
+use Soneso\StellarSDK\Xdr\XdrSorobanResources;
+use Soneso\StellarSDK\Xdr\XdrSorobanTransactionData;
+use Soneso\StellarSDK\Xdr\XdrSorobanTransactionDataExt;
+use Soneso\StellarSDK\Xdr\XdrSorobanTransactionMeta;
+use Soneso\StellarSDK\Xdr\XdrSorobanTransactionMetaExt;
+use Soneso\StellarSDK\Xdr\XdrTransactionMeta;
+use Soneso\StellarSDK\Xdr\XdrTransactionMetaV3;
+
+/**
+ * Test keypair that injects a mocked Guzzle HTTP client into internally created SorobanServer instances.
+ *
+ * SorobanClient and AssembledTransaction construct their SorobanServer internally from the rpcUrl,
+ * so there is no public seam for replacing the HTTP client before the first RPC call is made inside
+ * static factory flows such as SorobanClient::install(), SorobanClient::deploy() and
+ * AssembledTransaction::build(). All of those flows call sourceAccountKeyPair->getAccountId() from
+ * AssembledTransaction::getSourceAccount() right before the first RPC request. This subclass uses
+ * that deterministic call to locate the AssembledTransaction on the call stack and replace the
+ * private httpClient of its SorobanServer with the prepared mock client. The injection is idempotent;
+ * repeated calls simply re-assign the same client.
+ */
+class HttpInjectingKeyPair extends KeyPair
+{
+    private ?Client $httpClientToInject = null;
+
+    public static function fromBaseKeyPair(KeyPair $base): HttpInjectingKeyPair
+    {
+        return new HttpInjectingKeyPair($base->getPublicKey(), $base->getPrivateKey());
+    }
+
+    public function setHttpClientToInject(Client $client): void
+    {
+        $this->httpClientToInject = $client;
+    }
+
+    public function getAccountId(): string
+    {
+        if ($this->httpClientToInject !== null) {
+            foreach (debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT, 20) as $frame) {
+                $object = $frame['object'] ?? null;
+                if ($object instanceof AssembledTransaction) {
+                    $serverProperty = new ReflectionProperty(AssembledTransaction::class, 'server');
+                    $serverProperty->setAccessible(true);
+                    $server = $serverProperty->getValue($object);
+                    $httpClientProperty = new ReflectionProperty(SorobanServer::class, 'httpClient');
+                    $httpClientProperty->setAccessible(true);
+                    $httpClientProperty->setValue($server, $this->httpClientToInject);
+                }
+            }
+        }
+        return parent::getAccountId();
+    }
+}
+
+/**
+ * Unit tests for the SorobanClient high-level contract client.
+ *
+ * All RPC interactions are mocked with Guzzle MockHandler responses; no network access is required.
+ * The MockHandler queue doubles as a guard: any HTTP request beyond the queued responses fails the
+ * test, and an exhausted queue (count 0) proves that exactly the expected requests were made.
+ *
+ * Not covered here (no unit-test seam, requires a live RPC server):
+ * - SorobanClient::forClientOptions() constructs a SorobanServer directly and immediately performs
+ *   RPC calls, with no hook between construction and the first request.
+ * - SorobanClient::deploy() success path, because it ends with a forClientOptions() call.
+ */
+class SorobanClientTest extends TestCase
+{
+    private const TEST_ACCOUNT_ID = "GD56FXQWEQ34GBKJLU52QD3YB4CJSJCVPLOKISGZDRCYVIWZK5TMVDT3";
+    private const TEST_SECRET_SEED = "SAMKI63THJER2XVJA5LQXIPBWIV6FEFSS5ILURYGSCHFKZVDE5YVQWC7";
+    private const TEST_CONTRACT_ID = "CA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUWDA";
+    // Unroutable on purpose: all HTTP is served by the injected mock handler, and
+    // if injection ever fails the request errors out locally instead of reaching
+    // a live server.
+    private const TEST_RPC_URL = "http://localhost:1";
+    private const TEST_TX_HASH = "a4721e2a61e9a6b3f97c6b06427a2f8aacbdcbdbf30bbf52a4ce2c8fcbd2fc10";
+    private const TEST_WASM_HASH = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+    private Network $testNetwork;
+
+    public function setUp(): void
+    {
+        error_reporting(E_ALL);
+        $this->testNetwork = Network::testnet();
+    }
+
+    // ---------------------------------------------------------------------
+    // Constructor and getters
+    // ---------------------------------------------------------------------
+
+    public function testConstructorExtractsMethodNamesAndSkipsConstructorAndNonFunctionEntries(): void
+    {
+        $client = $this->createClient();
+
+        $this->assertSame(['hello', 'add'], $client->getMethodNames());
+    }
+
+    public function testGetters(): void
+    {
+        $specEntries = $this->createSpecEntries();
+        $options = $this->createClientOptions();
+        $client = $this->createClient($options, $specEntries);
+
+        $this->assertSame(self::TEST_CONTRACT_ID, $client->getContractId());
+        $this->assertSame($options, $client->getOptions());
+        $this->assertSame($specEntries, $client->getSpecEntries());
+
+        $contractSpec = $client->getContractSpec();
+        $this->assertInstanceOf(ContractSpec::class, $contractSpec);
+        $funcNames = array_map(fn($func) => $func->name, $contractSpec->funcs());
+        $this->assertSame(['hello', 'add', '__constructor'], $funcNames);
+    }
+
+    // ---------------------------------------------------------------------
+    // buildInvokeMethodTx
+    // ---------------------------------------------------------------------
+
+    public function testBuildInvokeMethodTxThrowsForUnknownMethod(): void
+    {
+        $client = $this->createClient();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage("Method 'transfer' does not exist");
+
+        $client->buildInvokeMethodTx('transfer');
+    }
+
+    public function testInvokeMethodThrowsForUnknownMethod(): void
+    {
+        $client = $this->createClient();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage("Method 'burn' does not exist");
+
+        $client->invokeMethod('burn');
+    }
+
+    public function testBuildInvokeMethodTxBuildsAndSimulatesTransaction(): void
+    {
+        $keyPair = HttpInjectingKeyPair::fromBaseKeyPair(KeyPair::fromAccountId(self::TEST_ACCOUNT_ID));
+        $client = $this->createClient($this->createClientOptions($keyPair));
+
+        $mock = new MockHandler([
+            $this->accountEntryResponse(),
+            $this->simulateResponse(XdrSCVal::forSymbol('ok')),
+        ]);
+        $keyPair->setHttpClientToInject($this->createHttpClient($mock));
+
+        $args = [XdrSCVal::forU32(42)];
+        $tx = $client->buildInvokeMethodTx('hello', $args);
+
+        $this->assertSame('hello', $tx->options->method);
+        $this->assertSame($args, $tx->options->arguments);
+
+        $this->assertNotNull($tx->tx);
+        $operations = $tx->tx->getOperations();
+        $this->assertCount(1, $operations);
+        $operation = $operations[0];
+        $this->assertInstanceOf(InvokeHostFunctionOperation::class, $operation);
+        $hostFunction = $operation->function;
+        $this->assertInstanceOf(InvokeContractHostFunction::class, $hostFunction);
+        $this->assertSame(self::TEST_CONTRACT_ID, $hostFunction->contractId);
+        $this->assertSame('hello', $hostFunction->functionName);
+        $this->assertNotNull($hostFunction->arguments);
+        $this->assertCount(1, $hostFunction->arguments);
+        $this->assertSame(42, $hostFunction->arguments[0]->getU32());
+
+        $this->assertNotNull($tx->simulationResponse);
+        $this->assertSame('ok', $tx->getSimulationData()->returnedValue->getSym());
+
+        // exactly getAccount + simulateTransaction were requested
+        $this->assertSame(0, $mock->count());
+    }
+
+    public function testBuildInvokeMethodTxHonorsMethodOptionsWithoutSimulation(): void
+    {
+        $keyPair = HttpInjectingKeyPair::fromBaseKeyPair(KeyPair::fromAccountId(self::TEST_ACCOUNT_ID));
+        $client = $this->createClient($this->createClientOptions($keyPair));
+
+        // only getAccount is expected; with simulate=false no simulateTransaction request may happen
+        $mock = new MockHandler([$this->accountEntryResponse()]);
+        $keyPair->setHttpClientToInject($this->createHttpClient($mock));
+
+        $methodOptions = new MethodOptions(fee: 500, timeoutInSeconds: 60, simulate: false);
+        $tx = $client->buildInvokeMethodTx('add', null, $methodOptions);
+
+        $this->assertSame($methodOptions, $tx->options->methodOptions);
+        $this->assertNotNull($tx->raw);
+        $this->assertNull($tx->tx);
+        $this->assertNull($tx->simulationResponse);
+        $this->assertSame(0, $mock->count());
+    }
+
+    // ---------------------------------------------------------------------
+    // invokeMethod
+    // ---------------------------------------------------------------------
+
+    public function testInvokeMethodReadCallReturnsSimulationResultWithoutSending(): void
+    {
+        $keyPair = HttpInjectingKeyPair::fromBaseKeyPair(KeyPair::fromAccountId(self::TEST_ACCOUNT_ID));
+        $client = $this->createClient($this->createClientOptions($keyPair));
+
+        // a read call must trigger exactly getAccount + simulateTransaction, never sendTransaction
+        $mock = new MockHandler([
+            $this->accountEntryResponse(),
+            $this->simulateResponse(XdrSCVal::forU32(1234)),
+        ]);
+        $keyPair->setHttpClientToInject($this->createHttpClient($mock));
+
+        $result = $client->invokeMethod('hello');
+
+        $this->assertSame(1234, $result->getU32());
+        $this->assertSame(0, $mock->count());
+    }
+
+    public function testInvokeMethodWriteCallSignsAndSends(): void
+    {
+        $args = [XdrSCVal::forU32(7)];
+        $response = $this->getTransactionResponse(
+            GetTransactionResponse::STATUS_SUCCESS,
+            XdrSCVal::forU32(99),
+        );
+
+        $tx = $this->createMock(AssembledTransaction::class);
+        $tx->method('isReadCall')->willReturn(false);
+        $tx->expects($this->once())->method('signAndSend')->with(null, false)->willReturn($response);
+
+        $client = $this->createClientWithStubbedBuild('hello', $args, null, $tx);
+
+        $result = $client->invokeMethod('hello', $args);
+
+        $this->assertSame(99, $result->getU32());
+    }
+
+    public function testInvokeMethodForceSkipsReadCallCheck(): void
+    {
+        $response = $this->getTransactionResponse(
+            GetTransactionResponse::STATUS_SUCCESS,
+            XdrSCVal::forSymbol('forced'),
+        );
+
+        $tx = $this->createMock(AssembledTransaction::class);
+        $tx->expects($this->never())->method('isReadCall');
+        $tx->expects($this->once())->method('signAndSend')->with(null, true)->willReturn($response);
+
+        $client = $this->createClientWithStubbedBuild('hello', null, null, $tx);
+
+        $result = $client->invokeMethod('hello', null, true);
+
+        $this->assertSame('forced', $result->getSym());
+    }
+
+    public function testInvokeMethodThrowsOnErrorResponse(): void
+    {
+        $response = new GetTransactionResponse([]);
+        $error = new SorobanRpcErrorResponse([]);
+        $error->code = -32600;
+        $error->message = 'simulated failure';
+        $response->error = $error;
+
+        $tx = $this->createMock(AssembledTransaction::class);
+        $tx->method('isReadCall')->willReturn(false);
+        $tx->method('signAndSend')->willReturn($response);
+
+        $client = $this->createClientWithStubbedBuild('hello', null, null, $tx);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('invoke hello failed with message: simulated failure and code: -32600');
+
+        $client->invokeMethod('hello');
+    }
+
+    public function testInvokeMethodThrowsOnNonSuccessStatus(): void
+    {
+        $response = $this->getTransactionResponse(GetTransactionResponse::STATUS_FAILED, null);
+        $response->resultXdr = 'AAAAFAILEDRESULT';
+
+        $tx = $this->createMock(AssembledTransaction::class);
+        $tx->method('isReadCall')->willReturn(false);
+        $tx->method('signAndSend')->willReturn($response);
+
+        $client = $this->createClientWithStubbedBuild('hello', null, null, $tx);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('invoke hello failed with result: AAAAFAILEDRESULT');
+
+        $client->invokeMethod('hello');
+    }
+
+    public function testInvokeMethodThrowsWhenResultValueMissing(): void
+    {
+        // status SUCCESS but no resultMetaXdr, so no return value can be extracted
+        $response = $this->getTransactionResponse(GetTransactionResponse::STATUS_SUCCESS, null);
+
+        $tx = $this->createMock(AssembledTransaction::class);
+        $tx->method('isReadCall')->willReturn(false);
+        $tx->method('signAndSend')->willReturn($response);
+
+        $client = $this->createClientWithStubbedBuild('hello', null, null, $tx);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('could not extract return value from hello invocation');
+
+        $client->invokeMethod('hello');
+    }
+
+    public function testInvokeMethodPassesMethodOptionsToBuild(): void
+    {
+        $methodOptions = new MethodOptions(fee: 1000);
+        $response = $this->getTransactionResponse(
+            GetTransactionResponse::STATUS_SUCCESS,
+            XdrSCVal::forU32(1),
+        );
+
+        $tx = $this->createMock(AssembledTransaction::class);
+        $tx->method('isReadCall')->willReturn(false);
+        $tx->method('signAndSend')->willReturn($response);
+
+        $client = $this->createClientWithStubbedBuild('add', null, $methodOptions, $tx);
+
+        $result = $client->invokeMethod('add', null, false, $methodOptions);
+
+        $this->assertSame(1, $result->getU32());
+    }
+
+    // ---------------------------------------------------------------------
+    // install
+    // ---------------------------------------------------------------------
+
+    public function testInstallReturnsWasmHashFromSimulationWhenAlreadyInstalled(): void
+    {
+        $keyPair = HttpInjectingKeyPair::fromBaseKeyPair(KeyPair::fromAccountId(self::TEST_ACCOUNT_ID));
+
+        // upload simulation of already installed code is a read call returning the wasm hash;
+        // no transaction may be submitted, so only getAccount + simulateTransaction are queued
+        $mock = new MockHandler([
+            $this->accountEntryResponse(),
+            $this->simulateResponse(XdrSCVal::forBytes(hex2bin(self::TEST_WASM_HASH))),
+        ]);
+        $keyPair->setHttpClientToInject($this->createHttpClient($mock));
+
+        $wasmHash = SorobanClient::install($this->createInstallRequest($keyPair));
+
+        $this->assertSame(self::TEST_WASM_HASH, $wasmHash);
+        $this->assertSame(0, $mock->count());
+    }
+
+    public function testInstallThrowsWhenSimulationReturnsNoBytes(): void
+    {
+        $keyPair = HttpInjectingKeyPair::fromBaseKeyPair(KeyPair::fromAccountId(self::TEST_ACCOUNT_ID));
+
+        $mock = new MockHandler([
+            $this->accountEntryResponse(),
+            $this->simulateResponse(XdrSCVal::forU32(5)),
+        ]);
+        $keyPair->setHttpClientToInject($this->createHttpClient($mock));
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Could not extract wasm hash from simulation result');
+
+        SorobanClient::install($this->createInstallRequest($keyPair));
+    }
+
+    public function testInstallForceSubmitsTransaction(): void
+    {
+        $keyPair = HttpInjectingKeyPair::fromBaseKeyPair(KeyPair::fromSeed(self::TEST_SECRET_SEED));
+
+        $mock = new MockHandler([
+            $this->accountEntryResponse(),
+            $this->simulateResponse(XdrSCVal::forBytes(hex2bin(self::TEST_WASM_HASH))),
+            $this->sendTransactionResponse(),
+            $this->getTransactionRpcResponse(
+                GetTransactionResponse::STATUS_SUCCESS,
+                XdrSCVal::forBytes(hex2bin(self::TEST_WASM_HASH)),
+            ),
+        ]);
+        $keyPair->setHttpClientToInject($this->createHttpClient($mock));
+
+        $wasmHash = SorobanClient::install($this->createInstallRequest($keyPair), true);
+
+        $this->assertSame(self::TEST_WASM_HASH, $wasmHash);
+        $this->assertSame(0, $mock->count());
+    }
+
+    public function testInstallForceThrowsWhenWasmHashMissing(): void
+    {
+        $keyPair = HttpInjectingKeyPair::fromBaseKeyPair(KeyPair::fromSeed(self::TEST_SECRET_SEED));
+
+        // transaction succeeds but contains no result meta, so no wasm hash can be extracted
+        $mock = new MockHandler([
+            $this->accountEntryResponse(),
+            $this->simulateResponse(XdrSCVal::forBytes(hex2bin(self::TEST_WASM_HASH))),
+            $this->sendTransactionResponse(),
+            $this->getTransactionRpcResponse(GetTransactionResponse::STATUS_SUCCESS, null),
+        ]);
+        $keyPair->setHttpClientToInject($this->createHttpClient($mock));
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Could not get wasm hash for installed contract');
+
+        SorobanClient::install($this->createInstallRequest($keyPair), true);
+    }
+
+    // ---------------------------------------------------------------------
+    // deploy
+    // ---------------------------------------------------------------------
+
+    public function testDeployThrowsWhenNoContractIdReturned(): void
+    {
+        $keyPair = HttpInjectingKeyPair::fromBaseKeyPair(KeyPair::fromSeed(self::TEST_SECRET_SEED));
+
+        $mock = new MockHandler([
+            $this->accountEntryResponse(),
+            $this->simulateResponse(XdrSCVal::forVoid(), true),
+            $this->sendTransactionResponse(),
+            $this->getTransactionRpcResponse(GetTransactionResponse::STATUS_FAILED, null),
+        ]);
+        $keyPair->setHttpClientToInject($this->createHttpClient($mock));
+
+        $deployRequest = new DeployRequest(
+            rpcUrl: self::TEST_RPC_URL,
+            network: $this->testNetwork,
+            sourceAccountKeyPair: $keyPair,
+            wasmHash: self::TEST_WASM_HASH,
+            constructorArgs: [XdrSCVal::forU32(1)],
+        );
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Could not get contract id for deployed contract');
+
+        SorobanClient::deploy($deployRequest);
+    }
+
+    // ---------------------------------------------------------------------
+    // helpers
+    // ---------------------------------------------------------------------
+
+    /**
+     * Creates a SorobanClient through its private constructor.
+     *
+     * @param ClientOptions|null $options client options, defaults to createClientOptions()
+     * @param array<XdrSCSpecEntry>|null $specEntries spec entries, defaults to createSpecEntries()
+     */
+    private function createClient(?ClientOptions $options = null, ?array $specEntries = null): SorobanClient
+    {
+        $reflection = new ReflectionClass(SorobanClient::class);
+        $client = $reflection->newInstanceWithoutConstructor();
+        $constructor = $reflection->getConstructor();
+        $constructor->setAccessible(true);
+        $constructor->invoke($client, $specEntries ?? $this->createSpecEntries(), $options ?? $this->createClientOptions());
+        return $client;
+    }
+
+    /**
+     * Creates a partial SorobanClient mock whose buildInvokeMethodTx returns the given transaction,
+     * so that invokeMethod can be exercised without any RPC interaction.
+     *
+     * @param string $method expected method name
+     * @param array<XdrSCVal>|null $args expected arguments
+     * @param MethodOptions|null $methodOptions expected method options
+     * @param AssembledTransaction $tx transaction to return from buildInvokeMethodTx
+     */
+    private function createClientWithStubbedBuild(
+        string $method,
+        ?array $args,
+        ?MethodOptions $methodOptions,
+        AssembledTransaction $tx,
+    ): SorobanClient {
+        $client = $this->getMockBuilder(SorobanClient::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['buildInvokeMethodTx'])
+            ->getMock();
+        $client->expects($this->once())
+            ->method('buildInvokeMethodTx')
+            ->with($method, $args, $methodOptions)
+            ->willReturn($tx);
+        return $client;
+    }
+
+    private function createClientOptions(?KeyPair $keyPair = null): ClientOptions
+    {
+        return new ClientOptions(
+            sourceAccountKeyPair: $keyPair ?? KeyPair::fromAccountId(self::TEST_ACCOUNT_ID),
+            contractId: self::TEST_CONTRACT_ID,
+            network: $this->testNetwork,
+            rpcUrl: self::TEST_RPC_URL,
+        );
+    }
+
+    private function createInstallRequest(KeyPair $keyPair): InstallRequest
+    {
+        return new InstallRequest(
+            wasmBytes: "\x00asm\x01\x00\x00\x00",
+            rpcUrl: self::TEST_RPC_URL,
+            network: $this->testNetwork,
+            sourceAccountKeyPair: $keyPair,
+        );
+    }
+
+    /**
+     * Spec entries with the functions hello and add, an UDT struct entry and a __constructor
+     * function entry. SorobanClient must expose only hello and add as method names.
+     *
+     * @return array<XdrSCSpecEntry>
+     */
+    private function createSpecEntries(): array
+    {
+        return [
+            $this->createFunctionEntry('hello'),
+            $this->createStructEntry('TestStruct'),
+            $this->createFunctionEntry('add'),
+            $this->createFunctionEntry('__constructor'),
+        ];
+    }
+
+    private function createFunctionEntry(string $name): XdrSCSpecEntry
+    {
+        $entry = new XdrSCSpecEntry(new XdrSCSpecEntryKind(XdrSCSpecEntryKind::SC_SPEC_ENTRY_FUNCTION_V0));
+        $entry->functionV0 = new XdrSCSpecFunctionV0(
+            '',
+            $name,
+            [],
+            [new XdrSCSpecTypeDef(XdrSCSpecType::VOID())],
+        );
+        return $entry;
+    }
+
+    private function createStructEntry(string $name): XdrSCSpecEntry
+    {
+        $entry = new XdrSCSpecEntry(new XdrSCSpecEntryKind(XdrSCSpecEntryKind::SC_SPEC_ENTRY_UDT_STRUCT_V0));
+        $entry->udtStructV0 = new XdrSCSpecUDTStructV0('', '', $name, []);
+        return $entry;
+    }
+
+    private function createHttpClient(MockHandler $mock): Client
+    {
+        return new Client(['handler' => HandlerStack::create($mock)]);
+    }
+
+    /**
+     * getLedgerEntries response containing the source account entry, as fetched by
+     * AssembledTransaction::getSourceAccount() via SorobanServer::getAccount().
+     */
+    private function accountEntryResponse(): Response
+    {
+        $accountEntry = new XdrAccountEntry(
+            accountID: new XdrAccountID(self::TEST_ACCOUNT_ID),
+            balance: new BigInteger(100000000),
+            seqNum: new XdrSequenceNumber(new BigInteger(123456789)),
+            numSubEntries: 0,
+            flags: 0,
+            homeDomain: '',
+            thresholds: "\x01\x00\x00\x00",
+            signers: [],
+            ext: new XdrAccountEntryExt(0),
+        );
+        $entryData = new XdrLedgerEntryData(XdrLedgerEntryType::ACCOUNT());
+        $entryData->account = $accountEntry;
+
+        return $this->jsonRpcResponse([
+            'entries' => [
+                [
+                    'key' => 'AAAAAA==',
+                    'xdr' => $entryData->toBase64Xdr(),
+                    'lastModifiedLedgerSeq' => 1000,
+                ],
+            ],
+            'latestLedger' => 1000,
+        ]);
+    }
+
+    /**
+     * simulateTransaction response. With $writeCall=false the footprint is empty, so the
+     * transaction is detected as a read call; with $writeCall=true the read-write footprint
+     * contains one entry, so signing and sending is required.
+     */
+    private function simulateResponse(XdrSCVal $returnedValue, bool $writeCall = false): Response
+    {
+        $readWrite = [];
+        if ($writeCall) {
+            $ledgerKey = new XdrLedgerKey(XdrLedgerEntryType::ACCOUNT());
+            $ledgerKey->account = new XdrLedgerKeyAccount(new XdrAccountID(self::TEST_ACCOUNT_ID));
+            $readWrite[] = $ledgerKey;
+        }
+        $footprint = new XdrLedgerFootprint([], $readWrite);
+        $resources = new XdrSorobanResources($footprint, 0, 0, 0);
+        $transactionData = new XdrSorobanTransactionData(new XdrSorobanTransactionDataExt(0), $resources, 0);
+
+        return $this->jsonRpcResponse([
+            'minResourceFee' => '100',
+            'latestLedger' => 1000,
+            'transactionData' => $transactionData->toBase64Xdr(),
+            'results' => [
+                [
+                    'auth' => [],
+                    'xdr' => $returnedValue->toBase64Xdr(),
+                ],
+            ],
+        ]);
+    }
+
+    private function sendTransactionResponse(): Response
+    {
+        return $this->jsonRpcResponse([
+            'status' => 'PENDING',
+            'hash' => self::TEST_TX_HASH,
+            'latestLedger' => 1000,
+            'latestLedgerCloseTime' => '1700000000',
+        ]);
+    }
+
+    /**
+     * getTransaction RPC response with the given status. If a return value is provided, it is
+     * wrapped in a TransactionMeta v3 sorobanMeta so that getResultValue() can extract it.
+     */
+    private function getTransactionRpcResponse(string $status, ?XdrSCVal $returnValue): Response
+    {
+        $result = [
+            'status' => $status,
+            'latestLedger' => 1001,
+            'latestLedgerCloseTime' => '1700000001',
+            'oldestLedger' => 990,
+            'oldestLedgerCloseTime' => '1699999000',
+        ];
+        if ($returnValue !== null) {
+            $result['resultMetaXdr'] = $this->transactionMetaXdr($returnValue);
+        }
+        return $this->jsonRpcResponse($result);
+    }
+
+    /**
+     * GetTransactionResponse object with the given status, for stubbing AssembledTransaction::signAndSend.
+     */
+    private function getTransactionResponse(string $status, ?XdrSCVal $returnValue): GetTransactionResponse
+    {
+        $response = new GetTransactionResponse([]);
+        $response->status = $status;
+        if ($returnValue !== null) {
+            $response->resultMetaXdr = $this->transactionMetaXdr($returnValue);
+        }
+        return $response;
+    }
+
+    private function transactionMetaXdr(XdrSCVal $returnValue): string
+    {
+        $sorobanMeta = new XdrSorobanTransactionMeta(
+            new XdrSorobanTransactionMetaExt(0),
+            [],
+            $returnValue,
+            [],
+        );
+        $meta = new XdrTransactionMeta(3);
+        $meta->v3 = new XdrTransactionMetaV3(new XdrExtensionPoint(0), [], [], [], $sorobanMeta);
+        return $meta->toBase64Xdr();
+    }
+
+    private function jsonRpcResponse(array $result): Response
+    {
+        return new Response(200, [], json_encode([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'result' => $result,
+        ]));
+    }
+}

--- a/Soneso/StellarSDKTests/Unit/Soroban/SorobanClientTest.php
+++ b/Soneso/StellarSDKTests/Unit/Soroban/SorobanClientTest.php
@@ -19,6 +19,7 @@ use Soneso\StellarSDK\Crypto\KeyPair;
 use Soneso\StellarSDK\InvokeContractHostFunction;
 use Soneso\StellarSDK\InvokeHostFunctionOperation;
 use Soneso\StellarSDK\Network;
+use Soneso\StellarSDK\Soroban\Address;
 use Soneso\StellarSDK\Soroban\Contract\AssembledTransaction;
 use Soneso\StellarSDK\Soroban\Contract\ClientOptions;
 use Soneso\StellarSDK\Soroban\Contract\ContractSpec;
@@ -32,12 +33,22 @@ use Soneso\StellarSDK\Soroban\SorobanServer;
 use Soneso\StellarSDK\Xdr\XdrAccountEntry;
 use Soneso\StellarSDK\Xdr\XdrAccountEntryExt;
 use Soneso\StellarSDK\Xdr\XdrAccountID;
+use Soneso\StellarSDK\Xdr\XdrContractCodeEntry;
+use Soneso\StellarSDK\Xdr\XdrContractCodeEntryExt;
+use Soneso\StellarSDK\Xdr\XdrContractDataDurability;
+use Soneso\StellarSDK\Xdr\XdrContractDataEntry;
+use Soneso\StellarSDK\Xdr\XdrContractExecutable;
+use Soneso\StellarSDK\Xdr\XdrDataValueMandatory;
 use Soneso\StellarSDK\Xdr\XdrExtensionPoint;
 use Soneso\StellarSDK\Xdr\XdrLedgerEntryData;
 use Soneso\StellarSDK\Xdr\XdrLedgerEntryType;
 use Soneso\StellarSDK\Xdr\XdrLedgerFootprint;
 use Soneso\StellarSDK\Xdr\XdrLedgerKey;
 use Soneso\StellarSDK\Xdr\XdrLedgerKeyAccount;
+use Soneso\StellarSDK\Xdr\XdrSCContractInstance;
+use Soneso\StellarSDK\Xdr\XdrSCEnvMetaEntry;
+use Soneso\StellarSDK\Xdr\XdrSCEnvMetaEntryInterfaceVersion;
+use Soneso\StellarSDK\Xdr\XdrSCEnvMetaKind;
 use Soneso\StellarSDK\Xdr\XdrSCSpecEntry;
 use Soneso\StellarSDK\Xdr\XdrSCSpecEntryKind;
 use Soneso\StellarSDK\Xdr\XdrSCSpecFunctionV0;
@@ -55,61 +66,13 @@ use Soneso\StellarSDK\Xdr\XdrTransactionMeta;
 use Soneso\StellarSDK\Xdr\XdrTransactionMetaV3;
 
 /**
- * Test keypair that injects a mocked Guzzle HTTP client into internally created SorobanServer instances.
- *
- * SorobanClient and AssembledTransaction construct their SorobanServer internally from the rpcUrl,
- * so there is no public seam for replacing the HTTP client before the first RPC call is made inside
- * static factory flows such as SorobanClient::install(), SorobanClient::deploy() and
- * AssembledTransaction::build(). All of those flows call sourceAccountKeyPair->getAccountId() from
- * AssembledTransaction::getSourceAccount() right before the first RPC request. This subclass uses
- * that deterministic call to locate the AssembledTransaction on the call stack and replace the
- * private httpClient of its SorobanServer with the prepared mock client. The injection is idempotent;
- * repeated calls simply re-assign the same client.
- */
-class HttpInjectingKeyPair extends KeyPair
-{
-    private ?Client $httpClientToInject = null;
-
-    public static function fromBaseKeyPair(KeyPair $base): HttpInjectingKeyPair
-    {
-        return new HttpInjectingKeyPair($base->getPublicKey(), $base->getPrivateKey());
-    }
-
-    public function setHttpClientToInject(Client $client): void
-    {
-        $this->httpClientToInject = $client;
-    }
-
-    public function getAccountId(): string
-    {
-        if ($this->httpClientToInject !== null) {
-            foreach (debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT, 20) as $frame) {
-                $object = $frame['object'] ?? null;
-                if ($object instanceof AssembledTransaction) {
-                    $serverProperty = new ReflectionProperty(AssembledTransaction::class, 'server');
-                    $serverProperty->setAccessible(true);
-                    $server = $serverProperty->getValue($object);
-                    $httpClientProperty = new ReflectionProperty(SorobanServer::class, 'httpClient');
-                    $httpClientProperty->setAccessible(true);
-                    $httpClientProperty->setValue($server, $this->httpClientToInject);
-                }
-            }
-        }
-        return parent::getAccountId();
-    }
-}
-
-/**
  * Unit tests for the SorobanClient high-level contract client.
  *
  * All RPC interactions are mocked with Guzzle MockHandler responses; no network access is required.
- * The MockHandler queue doubles as a guard: any HTTP request beyond the queued responses fails the
- * test, and an exhausted queue (count 0) proves that exactly the expected requests were made.
- *
- * Not covered here (no unit-test seam, requires a live RPC server):
- * - SorobanClient::forClientOptions() constructs a SorobanServer directly and immediately performs
- *   RPC calls, with no hook between construction and the first request.
- * - SorobanClient::deploy() success path, because it ends with a forClientOptions() call.
+ * A SorobanServer whose private httpClient is replaced with a mock-backed Guzzle client is passed
+ * through the server option of ClientOptions, InstallRequest and DeployRequest. The MockHandler
+ * queue doubles as a guard: any HTTP request beyond the queued responses fails the test, and an
+ * exhausted queue (count 0) proves that exactly the expected requests were made.
  */
 class SorobanClientTest extends TestCase
 {
@@ -184,14 +147,13 @@ class SorobanClientTest extends TestCase
 
     public function testBuildInvokeMethodTxBuildsAndSimulatesTransaction(): void
     {
-        $keyPair = HttpInjectingKeyPair::fromBaseKeyPair(KeyPair::fromAccountId(self::TEST_ACCOUNT_ID));
-        $client = $this->createClient($this->createClientOptions($keyPair));
-
         $mock = new MockHandler([
             $this->accountEntryResponse(),
             $this->simulateResponse(XdrSCVal::forSymbol('ok')),
         ]);
-        $keyPair->setHttpClientToInject($this->createHttpClient($mock));
+        $server = $this->createMockedServer($mock);
+        $keyPair = KeyPair::fromAccountId(self::TEST_ACCOUNT_ID);
+        $client = $this->createClient($this->createClientOptions($keyPair, $server));
 
         $args = [XdrSCVal::forU32(42)];
         $tx = $client->buildInvokeMethodTx('hello', $args);
@@ -221,12 +183,11 @@ class SorobanClientTest extends TestCase
 
     public function testBuildInvokeMethodTxHonorsMethodOptionsWithoutSimulation(): void
     {
-        $keyPair = HttpInjectingKeyPair::fromBaseKeyPair(KeyPair::fromAccountId(self::TEST_ACCOUNT_ID));
-        $client = $this->createClient($this->createClientOptions($keyPair));
-
         // only getAccount is expected; with simulate=false no simulateTransaction request may happen
         $mock = new MockHandler([$this->accountEntryResponse()]);
-        $keyPair->setHttpClientToInject($this->createHttpClient($mock));
+        $server = $this->createMockedServer($mock);
+        $keyPair = KeyPair::fromAccountId(self::TEST_ACCOUNT_ID);
+        $client = $this->createClient($this->createClientOptions($keyPair, $server));
 
         $methodOptions = new MethodOptions(fee: 500, timeoutInSeconds: 60, simulate: false);
         $tx = $client->buildInvokeMethodTx('add', null, $methodOptions);
@@ -244,15 +205,14 @@ class SorobanClientTest extends TestCase
 
     public function testInvokeMethodReadCallReturnsSimulationResultWithoutSending(): void
     {
-        $keyPair = HttpInjectingKeyPair::fromBaseKeyPair(KeyPair::fromAccountId(self::TEST_ACCOUNT_ID));
-        $client = $this->createClient($this->createClientOptions($keyPair));
-
         // a read call must trigger exactly getAccount + simulateTransaction, never sendTransaction
         $mock = new MockHandler([
             $this->accountEntryResponse(),
             $this->simulateResponse(XdrSCVal::forU32(1234)),
         ]);
-        $keyPair->setHttpClientToInject($this->createHttpClient($mock));
+        $server = $this->createMockedServer($mock);
+        $keyPair = KeyPair::fromAccountId(self::TEST_ACCOUNT_ID);
+        $client = $this->createClient($this->createClientOptions($keyPair, $server));
 
         $result = $client->invokeMethod('hello');
 
@@ -376,17 +336,16 @@ class SorobanClientTest extends TestCase
 
     public function testInstallReturnsWasmHashFromSimulationWhenAlreadyInstalled(): void
     {
-        $keyPair = HttpInjectingKeyPair::fromBaseKeyPair(KeyPair::fromAccountId(self::TEST_ACCOUNT_ID));
-
         // upload simulation of already installed code is a read call returning the wasm hash;
         // no transaction may be submitted, so only getAccount + simulateTransaction are queued
         $mock = new MockHandler([
             $this->accountEntryResponse(),
             $this->simulateResponse(XdrSCVal::forBytes(hex2bin(self::TEST_WASM_HASH))),
         ]);
-        $keyPair->setHttpClientToInject($this->createHttpClient($mock));
+        $server = $this->createMockedServer($mock);
+        $keyPair = KeyPair::fromAccountId(self::TEST_ACCOUNT_ID);
 
-        $wasmHash = SorobanClient::install($this->createInstallRequest($keyPair));
+        $wasmHash = SorobanClient::install($this->createInstallRequest($keyPair, $server));
 
         $this->assertSame(self::TEST_WASM_HASH, $wasmHash);
         $this->assertSame(0, $mock->count());
@@ -394,24 +353,21 @@ class SorobanClientTest extends TestCase
 
     public function testInstallThrowsWhenSimulationReturnsNoBytes(): void
     {
-        $keyPair = HttpInjectingKeyPair::fromBaseKeyPair(KeyPair::fromAccountId(self::TEST_ACCOUNT_ID));
-
         $mock = new MockHandler([
             $this->accountEntryResponse(),
             $this->simulateResponse(XdrSCVal::forU32(5)),
         ]);
-        $keyPair->setHttpClientToInject($this->createHttpClient($mock));
+        $server = $this->createMockedServer($mock);
+        $keyPair = KeyPair::fromAccountId(self::TEST_ACCOUNT_ID);
 
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('Could not extract wasm hash from simulation result');
 
-        SorobanClient::install($this->createInstallRequest($keyPair));
+        SorobanClient::install($this->createInstallRequest($keyPair, $server));
     }
 
     public function testInstallForceSubmitsTransaction(): void
     {
-        $keyPair = HttpInjectingKeyPair::fromBaseKeyPair(KeyPair::fromSeed(self::TEST_SECRET_SEED));
-
         $mock = new MockHandler([
             $this->accountEntryResponse(),
             $this->simulateResponse(XdrSCVal::forBytes(hex2bin(self::TEST_WASM_HASH))),
@@ -421,9 +377,10 @@ class SorobanClientTest extends TestCase
                 XdrSCVal::forBytes(hex2bin(self::TEST_WASM_HASH)),
             ),
         ]);
-        $keyPair->setHttpClientToInject($this->createHttpClient($mock));
+        $server = $this->createMockedServer($mock);
+        $keyPair = KeyPair::fromSeed(self::TEST_SECRET_SEED);
 
-        $wasmHash = SorobanClient::install($this->createInstallRequest($keyPair), true);
+        $wasmHash = SorobanClient::install($this->createInstallRequest($keyPair, $server), true);
 
         $this->assertSame(self::TEST_WASM_HASH, $wasmHash);
         $this->assertSame(0, $mock->count());
@@ -431,8 +388,6 @@ class SorobanClientTest extends TestCase
 
     public function testInstallForcePollsUntilTransactionFound(): void
     {
-        $keyPair = HttpInjectingKeyPair::fromBaseKeyPair(KeyPair::fromSeed(self::TEST_SECRET_SEED));
-
         // The first getTransaction poll reports NOT_FOUND; the status polling
         // retries with backoff until the transaction is found.
         $mock = new MockHandler([
@@ -445,9 +400,10 @@ class SorobanClientTest extends TestCase
                 XdrSCVal::forBytes(hex2bin(self::TEST_WASM_HASH)),
             ),
         ]);
-        $keyPair->setHttpClientToInject($this->createHttpClient($mock));
+        $server = $this->createMockedServer($mock);
+        $keyPair = KeyPair::fromSeed(self::TEST_SECRET_SEED);
 
-        $wasmHash = SorobanClient::install($this->createInstallRequest($keyPair), true);
+        $wasmHash = SorobanClient::install($this->createInstallRequest($keyPair, $server), true);
 
         $this->assertSame(self::TEST_WASM_HASH, $wasmHash);
         $this->assertSame(0, $mock->count());
@@ -455,8 +411,6 @@ class SorobanClientTest extends TestCase
 
     public function testInstallForceThrowsWhenWasmHashMissing(): void
     {
-        $keyPair = HttpInjectingKeyPair::fromBaseKeyPair(KeyPair::fromSeed(self::TEST_SECRET_SEED));
-
         // transaction succeeds but contains no result meta, so no wasm hash can be extracted
         $mock = new MockHandler([
             $this->accountEntryResponse(),
@@ -464,12 +418,13 @@ class SorobanClientTest extends TestCase
             $this->sendTransactionResponse(),
             $this->getTransactionRpcResponse(GetTransactionResponse::STATUS_SUCCESS, null),
         ]);
-        $keyPair->setHttpClientToInject($this->createHttpClient($mock));
+        $server = $this->createMockedServer($mock);
+        $keyPair = KeyPair::fromSeed(self::TEST_SECRET_SEED);
 
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('Could not get wasm hash for installed contract');
 
-        SorobanClient::install($this->createInstallRequest($keyPair), true);
+        SorobanClient::install($this->createInstallRequest($keyPair, $server), true);
     }
 
     // ---------------------------------------------------------------------
@@ -478,15 +433,14 @@ class SorobanClientTest extends TestCase
 
     public function testDeployThrowsWhenNoContractIdReturned(): void
     {
-        $keyPair = HttpInjectingKeyPair::fromBaseKeyPair(KeyPair::fromSeed(self::TEST_SECRET_SEED));
-
         $mock = new MockHandler([
             $this->accountEntryResponse(),
             $this->simulateResponse(XdrSCVal::forVoid(), true),
             $this->sendTransactionResponse(),
             $this->getTransactionRpcResponse(GetTransactionResponse::STATUS_FAILED, null),
         ]);
-        $keyPair->setHttpClientToInject($this->createHttpClient($mock));
+        $server = $this->createMockedServer($mock);
+        $keyPair = KeyPair::fromSeed(self::TEST_SECRET_SEED);
 
         $deployRequest = new DeployRequest(
             rpcUrl: self::TEST_RPC_URL,
@@ -494,12 +448,53 @@ class SorobanClientTest extends TestCase
             sourceAccountKeyPair: $keyPair,
             wasmHash: self::TEST_WASM_HASH,
             constructorArgs: [XdrSCVal::forU32(1)],
+            server: $server,
         );
 
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('Could not get contract id for deployed contract');
 
         SorobanClient::deploy($deployRequest);
+    }
+
+    // ---------------------------------------------------------------------
+    // forClientOptions
+    // ---------------------------------------------------------------------
+
+    public function testForClientOptionsLoadsSpecFromChain(): void
+    {
+        $wasmHash = hash('sha256', 'test-wasm', true);
+        $byteCode = $this->createContractByteCode('hello');
+
+        // forClientOptions loads the contract instance entry first to resolve the wasm id,
+        // then the contract code entry containing the byte code with the embedded spec
+        $mock = new MockHandler([
+            $this->ledgerEntryResponse($this->contractInstanceEntryData($wasmHash)),
+            $this->ledgerEntryResponse($this->contractCodeEntryData($wasmHash, $byteCode)),
+        ]);
+        $server = $this->createMockedServer($mock);
+
+        $client = SorobanClient::forClientOptions($this->createClientOptions(server: $server));
+
+        $this->assertContains('hello', $client->getMethodNames());
+        $this->assertSame(self::TEST_CONTRACT_ID, $client->getContractId());
+        $this->assertSame(0, $mock->count());
+    }
+
+    public function testForClientOptionsThrowsWhenContractNotFound(): void
+    {
+        $mock = new MockHandler([
+            $this->jsonRpcResponse([
+                'entries' => [],
+                'latestLedger' => 1000,
+            ]),
+        ]);
+        $server = $this->createMockedServer($mock);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Could not load contract info for the contract');
+
+        SorobanClient::forClientOptions($this->createClientOptions(server: $server));
     }
 
     // ---------------------------------------------------------------------
@@ -548,24 +543,39 @@ class SorobanClientTest extends TestCase
         return $client;
     }
 
-    private function createClientOptions(?KeyPair $keyPair = null): ClientOptions
+    private function createClientOptions(?KeyPair $keyPair = null, ?SorobanServer $server = null): ClientOptions
     {
         return new ClientOptions(
             sourceAccountKeyPair: $keyPair ?? KeyPair::fromAccountId(self::TEST_ACCOUNT_ID),
             contractId: self::TEST_CONTRACT_ID,
             network: $this->testNetwork,
             rpcUrl: self::TEST_RPC_URL,
+            server: $server,
         );
     }
 
-    private function createInstallRequest(KeyPair $keyPair): InstallRequest
+    private function createInstallRequest(KeyPair $keyPair, ?SorobanServer $server = null): InstallRequest
     {
         return new InstallRequest(
             wasmBytes: "\x00asm\x01\x00\x00\x00",
             rpcUrl: self::TEST_RPC_URL,
             network: $this->testNetwork,
             sourceAccountKeyPair: $keyPair,
+            server: $server,
         );
+    }
+
+    /**
+     * SorobanServer whose private httpClient is replaced with a Guzzle client backed by the
+     * given mock handler, so that all RPC requests are served from the queued responses.
+     */
+    private function createMockedServer(MockHandler $mock): SorobanServer
+    {
+        $server = new SorobanServer(self::TEST_RPC_URL);
+        $httpClientProperty = new ReflectionProperty(SorobanServer::class, 'httpClient');
+        $httpClientProperty->setAccessible(true);
+        $httpClientProperty->setValue($server, $this->createHttpClient($mock));
+        return $server;
     }
 
     /**
@@ -606,6 +616,68 @@ class SorobanClientTest extends TestCase
     private function createHttpClient(MockHandler $mock): Client
     {
         return new Client(['handler' => HandlerStack::create($mock)]);
+    }
+
+    /**
+     * Synthetic contract byte code containing an env meta section followed by a spec section
+     * with a single function entry, as parsed by SorobanContractParser.
+     */
+    private function createContractByteCode(string $functionName): string
+    {
+        $envMeta = new XdrSCEnvMetaEntry(new XdrSCEnvMetaKind(XdrSCEnvMetaKind::SC_ENV_META_KIND_INTERFACE_VERSION));
+        $envMeta->interfaceVersion = new XdrSCEnvMetaEntryInterfaceVersion(23, 0);
+        $specEntry = $this->createFunctionEntry($functionName);
+        return 'contractenvmetav0' . $envMeta->encode() . 'contractspecv0' . $specEntry->encode();
+    }
+
+    /**
+     * CONTRACT_DATA ledger entry holding the contract instance with a wasm executable.
+     */
+    private function contractInstanceEntryData(string $wasmHash): XdrLedgerEntryData
+    {
+        $instance = new XdrSCContractInstance(XdrContractExecutable::forWasmId(bin2hex($wasmHash)));
+        $dataEntry = new XdrContractDataEntry(
+            new XdrExtensionPoint(0),
+            Address::fromContractId(self::TEST_CONTRACT_ID)->toXdr(),
+            XdrSCVal::forLedgerKeyContractInstance(),
+            XdrContractDataDurability::PERSISTENT(),
+            XdrSCVal::forContractInstance($instance),
+        );
+        $entryData = new XdrLedgerEntryData(XdrLedgerEntryType::CONTRACT_DATA());
+        $entryData->contractData = $dataEntry;
+        return $entryData;
+    }
+
+    /**
+     * CONTRACT_CODE ledger entry holding the given byte code under the given wasm hash.
+     */
+    private function contractCodeEntryData(string $wasmHash, string $byteCode): XdrLedgerEntryData
+    {
+        $codeEntry = new XdrContractCodeEntry(
+            new XdrContractCodeEntryExt(0),
+            $wasmHash,
+            new XdrDataValueMandatory($byteCode),
+        );
+        $entryData = new XdrLedgerEntryData(XdrLedgerEntryType::CONTRACT_CODE());
+        $entryData->contractCode = $codeEntry;
+        return $entryData;
+    }
+
+    /**
+     * getLedgerEntries response containing the given ledger entry as its single result.
+     */
+    private function ledgerEntryResponse(XdrLedgerEntryData $entryData): Response
+    {
+        return $this->jsonRpcResponse([
+            'entries' => [
+                [
+                    'key' => 'AAAABgAAAAA=',
+                    'xdr' => $entryData->toBase64Xdr(),
+                    'lastModifiedLedgerSeq' => 1000,
+                ],
+            ],
+            'latestLedger' => 1000,
+        ]);
     }
 
     /**

--- a/Soneso/StellarSDKTests/Unit/Soroban/SorobanClientTest.php
+++ b/Soneso/StellarSDKTests/Unit/Soroban/SorobanClientTest.php
@@ -429,6 +429,30 @@ class SorobanClientTest extends TestCase
         $this->assertSame(0, $mock->count());
     }
 
+    public function testInstallForcePollsUntilTransactionFound(): void
+    {
+        $keyPair = HttpInjectingKeyPair::fromBaseKeyPair(KeyPair::fromSeed(self::TEST_SECRET_SEED));
+
+        // The first getTransaction poll reports NOT_FOUND; the status polling
+        // retries with backoff until the transaction is found.
+        $mock = new MockHandler([
+            $this->accountEntryResponse(),
+            $this->simulateResponse(XdrSCVal::forBytes(hex2bin(self::TEST_WASM_HASH))),
+            $this->sendTransactionResponse(),
+            $this->getTransactionRpcResponse(GetTransactionResponse::STATUS_NOT_FOUND, null),
+            $this->getTransactionRpcResponse(
+                GetTransactionResponse::STATUS_SUCCESS,
+                XdrSCVal::forBytes(hex2bin(self::TEST_WASM_HASH)),
+            ),
+        ]);
+        $keyPair->setHttpClientToInject($this->createHttpClient($mock));
+
+        $wasmHash = SorobanClient::install($this->createInstallRequest($keyPair), true);
+
+        $this->assertSame(self::TEST_WASM_HASH, $wasmHash);
+        $this->assertSame(0, $mock->count());
+    }
+
     public function testInstallForceThrowsWhenWasmHashMissing(): void
     {
         $keyPair = HttpInjectingKeyPair::fromBaseKeyPair(KeyPair::fromSeed(self::TEST_SECRET_SEED));

--- a/Soneso/StellarSDKTests/Unit/Util/UtilTest.php
+++ b/Soneso/StellarSDKTests/Unit/Util/UtilTest.php
@@ -121,6 +121,14 @@ class UtilTest extends TestCase
         StellarAmount::fromString("922337203686");
     }
 
+    public function testStellarAmountExceedsMaximumByOneStroop()
+    {
+        // The maximum is 9223372036854775807 stroops; one stroop more must be rejected.
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Maximum value exceeded");
+        new StellarAmount(new \phpseclib3\Math\BigInteger('9223372036854775808'));
+    }
+
     public function testStellarAmountNegative()
     {
         $this->expectException(InvalidArgumentException::class);

--- a/Soneso/StellarSDKTests/Unit/Xdr/XdrCodecPrimitivesTest.php
+++ b/Soneso/StellarSDKTests/Unit/Xdr/XdrCodecPrimitivesTest.php
@@ -1,0 +1,70 @@
+<?php declare(strict_types=1);
+
+// Copyright 2026 The Stellar PHP SDK Authors. All rights reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+namespace Soneso\StellarSDKTests\Unit\Xdr;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use Soneso\StellarSDK\Xdr\XdrDecoder;
+use Soneso\StellarSDK\Xdr\XdrEncoder;
+
+/**
+ * Tests for the low-level XDR primitive codec (XdrDecoder / XdrEncoder).
+ */
+class XdrCodecPrimitivesTest extends TestCase
+{
+    public function testBooleanDecodesTrueAndFalse(): void
+    {
+        // XDR boolean is a 4-byte big-endian uint32: 0 = false, 1 = true.
+        $this->assertFalse(XdrDecoder::boolean("\x00\x00\x00\x00"));
+        $this->assertTrue(XdrDecoder::boolean("\x00\x00\x00\x01"));
+    }
+
+    public function testBooleanRejectsNonBooleanValue(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unexpected XDR for a boolean value');
+        XdrDecoder::boolean("\x00\x00\x00\x02");
+    }
+
+    public function testUnsignedInteger32RoundTrip(): void
+    {
+        foreach ([0, 1, 255, 65535, 2147483648, 4294967295] as $v) {
+            $this->assertSame($v, XdrDecoder::unsignedInteger(XdrEncoder::unsignedInteger32($v)));
+        }
+    }
+
+    public function testSignedInteger32RoundTrip(): void
+    {
+        foreach ([0, 1, -1, 2147483647, -2147483648] as $v) {
+            $this->assertSame($v, XdrDecoder::signedInteger(XdrEncoder::integer32($v)));
+        }
+    }
+
+    public function testInteger64RoundTrip(): void
+    {
+        foreach ([0, 1, -1, PHP_INT_MAX, PHP_INT_MIN] as $v) {
+            $this->assertSame($v, XdrDecoder::signedInteger64(XdrEncoder::integer64($v)));
+        }
+        foreach ([0, 1, 9223372036854775807] as $v) {
+            $this->assertSame($v, XdrDecoder::unsignedInteger64(XdrEncoder::unsignedInteger64($v)));
+        }
+    }
+
+    public function testOpaqueFixedRejectsOverlongValue(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        XdrEncoder::opaqueFixed("\x01\x02\x03\x04\x05", 4);
+    }
+
+    public function testOpaqueFixedPadsToExpectedLength(): void
+    {
+        // 3 bytes padded to a 4-byte boundary (XDR pads to multiples of 4).
+        $encoded = XdrEncoder::opaqueFixed("\x01\x02\x03", 3);
+        $this->assertSame(4, strlen($encoded));
+        $this->assertSame("\x01\x02\x03\x00", $encoded);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -36,9 +36,11 @@
 	"require-dev" : {
 		"phpunit/phpunit" : "~10.0",
 		"phpdocumentor/phpdocumentor": "^3.9",
-		"league/uri": "7.5.1"
+		"league/uri": "7.5.1",
+		"phpstan/phpstan": "^2.2"
 	},
 	"scripts": {
+		"analyse": "phpstan analyse --memory-limit=2G",
 		"test": "phpunit --testsuite unit",
 		"test:integration": "phpunit --testsuite integration",
 		"test:all": "phpunit --testsuite all",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,4087 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Class Soneso\\StellarSDK\\SetTrustLineFlagsOperation referenced with incorrect case\: Soneso\\StellarSDK\\SetTrustlineFlagsOperation\.$#'
+			identifier: class.nameCase
+			count: 1
+			path: Soneso/StellarSDK/AbstractOperation.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Asset\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Asset.php
+
+		-
+			message: '#^Instanceof between Soneso\\StellarSDK\\Claimant and Soneso\\StellarSDK\\Claimant will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
+			count: 1
+			path: Soneso/StellarSDK/CreateClaimableBalanceOperation.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\CreateContractWithConstructorHostFunction\:\:getConstructorArgs\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/CreateContractWithConstructorHostFunction.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\CreateContractWithConstructorHostFunction\:\:setConstructorArgs\(\) has parameter \$constructorArgs with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/CreateContractWithConstructorHostFunction.php
+
+		-
+			message: '#^Unsafe call to private method Soneso\\StellarSDK\\Crypto\\StrKey\:\:calculateChecksum\(\) through static\:\:\.$#'
+			identifier: staticClassAccess.privateMethod
+			count: 2
+			path: Soneso/StellarSDK/Crypto/StrKey.php
+
+		-
+			message: '#^Unsafe call to private method Soneso\\StellarSDK\\Crypto\\StrKey\:\:decodeCheck\(\) through static\:\:\.$#'
+			identifier: staticClassAccess.privateMethod
+			count: 11
+			path: Soneso/StellarSDK/Crypto/StrKey.php
+
+		-
+			message: '#^Unsafe call to private method Soneso\\StellarSDK\\Crypto\\StrKey\:\:encodeCheck\(\) through static\:\:\.$#'
+			identifier: staticClassAccess.privateMethod
+			count: 13
+			path: Soneso/StellarSDK/Crypto/StrKey.php
+
+		-
+			message: '#^Unsafe call to private method Soneso\\StellarSDK\\Crypto\\StrKey\:\:isValid\(\) through static\:\:\.$#'
+			identifier: staticClassAccess.privateMethod
+			count: 8
+			path: Soneso/StellarSDK/Crypto/StrKey.php
+
+		-
+			message: '#^Unsafe call to private method Soneso\\StellarSDK\\Crypto\\StrKey\:\:verifyChecksum\(\) through static\:\:\.$#'
+			identifier: staticClassAccess.privateMethod
+			count: 1
+			path: Soneso/StellarSDK/Crypto/StrKey.php
+
+		-
+			message: '#^Deprecated in PHP 8\.4\: Parameter \#2 \$previous \(Throwable\) is implicitly nullable via default value null\.$#'
+			identifier: parameter.implicitlyNullable
+			count: 1
+			path: Soneso/StellarSDK/Exceptions/HorizonRequestException.php
+
+		-
+			message: '#^Comparison operation "\<" between int\<100, max\> and 0 is always false\.$#'
+			identifier: smaller.alwaysFalse
+			count: 1
+			path: Soneso/StellarSDK/FeeBumpTransactionBuilder.php
+
+		-
+			message: '#^Instanceof between Soneso\\StellarSDK\\Asset and Soneso\\StellarSDK\\Asset will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
+			count: 1
+			path: Soneso/StellarSDK/PathPaymentStrictReceiveOperation.php
+
+		-
+			message: '#^Instanceof between Soneso\\StellarSDK\\Asset and Soneso\\StellarSDK\\Asset will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
+			count: 1
+			path: Soneso/StellarSDK/PathPaymentStrictReceiveOperationBuilder.php
+
+		-
+			message: '#^Instanceof between Soneso\\StellarSDK\\Asset and Soneso\\StellarSDK\\Asset will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
+			count: 1
+			path: Soneso/StellarSDK/PathPaymentStrictSendOperation.php
+
+		-
+			message: '#^Instanceof between Soneso\\StellarSDK\\Asset and Soneso\\StellarSDK\\Asset will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
+			count: 1
+			path: Soneso/StellarSDK/PathPaymentStrictSendOperationBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Price\:\:float2fraction\(\) has parameter \$n with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: Soneso/StellarSDK/Price.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Price\:\:float2fraction\(\) has parameter \$tolerance with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: Soneso/StellarSDK/Price.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Price\:\:float2fraction\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Price.php
+
+		-
+			message: '#^Class Soneso\\StellarSDK\\AssetTypeCreditAlphanum referenced with incorrect case\: Soneso\\StellarSDK\\AssetTypeCreditAlphaNum\.$#'
+			identifier: class.nameCase
+			count: 2
+			path: Soneso/StellarSDK/Requests/AccountsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\AccountsRequestBuilder\:\:account\(\) should return Soneso\\StellarSDK\\Responses\\Account\\AccountResponse but returns Soneso\\StellarSDK\\Responses\\Response\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/AccountsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\AccountsRequestBuilder\:\:accountData\(\) should return Soneso\\StellarSDK\\Responses\\Account\\AccountDataValueResponse but returns Soneso\\StellarSDK\\Responses\\Response\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/AccountsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\AccountsRequestBuilder\:\:cursor\(\) should return Soneso\\StellarSDK\\Requests\\AccountsRequestBuilder but returns Soneso\\StellarSDK\\Requests\\RequestBuilder\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/AccountsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\AccountsRequestBuilder\:\:limit\(\) should return Soneso\\StellarSDK\\Requests\\AccountsRequestBuilder but returns Soneso\\StellarSDK\\Requests\\RequestBuilder\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/AccountsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\AccountsRequestBuilder\:\:order\(\) should return Soneso\\StellarSDK\\Requests\\AccountsRequestBuilder but returns Soneso\\StellarSDK\\Requests\\RequestBuilder\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/AccountsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\AccountsRequestBuilder\:\:request\(\) should return Soneso\\StellarSDK\\Responses\\Account\\AccountsPageResponse but returns Soneso\\StellarSDK\\Responses\\Response\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/AccountsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\AccountsRequestBuilder\:\:streamAccount\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: Soneso/StellarSDK/Requests/AccountsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\AssetsRequestBuilder\:\:cursor\(\) should return Soneso\\StellarSDK\\Requests\\AssetsRequestBuilder but returns Soneso\\StellarSDK\\Requests\\RequestBuilder\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/AssetsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\AssetsRequestBuilder\:\:limit\(\) should return Soneso\\StellarSDK\\Requests\\AssetsRequestBuilder but returns Soneso\\StellarSDK\\Requests\\RequestBuilder\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/AssetsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\AssetsRequestBuilder\:\:order\(\) should return Soneso\\StellarSDK\\Requests\\AssetsRequestBuilder but returns Soneso\\StellarSDK\\Requests\\RequestBuilder\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/AssetsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\AssetsRequestBuilder\:\:request\(\) should return Soneso\\StellarSDK\\Responses\\Asset\\AssetsPageResponse but returns Soneso\\StellarSDK\\Responses\\Response\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/AssetsRequestBuilder.php
+
+		-
+			message: '#^PHPDoc tag @param has invalid value \(int number maximum number of records to return\)\: Unexpected token "number", expected variable at offset 217 on line 5$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: Soneso/StellarSDK/Requests/AssetsRequestBuilder.php
+
+		-
+			message: '#^PHPDoc tag @param has invalid value \(string cursor\)\: Unexpected token "cursor", expected variable at offset 372 on line 6$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: Soneso/StellarSDK/Requests/AssetsRequestBuilder.php
+
+		-
+			message: '#^PHPDoc tag @param has invalid value \(string direction "asc" or "desc"\)\: Unexpected token "direction", expected variable at offset 82 on line 3$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: Soneso/StellarSDK/Requests/AssetsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\ClaimableBalancesRequestBuilder\:\:claimableBalance\(\) should return Soneso\\StellarSDK\\Responses\\ClaimableBalances\\ClaimableBalanceResponse but returns Soneso\\StellarSDK\\Responses\\Response\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/ClaimableBalancesRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\ClaimableBalancesRequestBuilder\:\:cursor\(\) should return Soneso\\StellarSDK\\Requests\\ClaimableBalancesRequestBuilder but returns Soneso\\StellarSDK\\Requests\\RequestBuilder\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/ClaimableBalancesRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\ClaimableBalancesRequestBuilder\:\:limit\(\) should return Soneso\\StellarSDK\\Requests\\ClaimableBalancesRequestBuilder but returns Soneso\\StellarSDK\\Requests\\RequestBuilder\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/ClaimableBalancesRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\ClaimableBalancesRequestBuilder\:\:order\(\) should return Soneso\\StellarSDK\\Requests\\ClaimableBalancesRequestBuilder but returns Soneso\\StellarSDK\\Requests\\RequestBuilder\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/ClaimableBalancesRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\ClaimableBalancesRequestBuilder\:\:request\(\) should return Soneso\\StellarSDK\\Responses\\ClaimableBalances\\ClaimableBalancesPageResponse but returns Soneso\\StellarSDK\\Responses\\Response\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/ClaimableBalancesRequestBuilder.php
+
+		-
+			message: '#^Deprecated in PHP 8\.4\: Parameter \#1 \$callback \(callable\) is implicitly nullable via default value null\.$#'
+			identifier: parameter.implicitlyNullable
+			count: 1
+			path: Soneso/StellarSDK/Requests/EffectsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\EffectsRequestBuilder\:\:cursor\(\) should return Soneso\\StellarSDK\\Requests\\EffectsRequestBuilder but returns Soneso\\StellarSDK\\Requests\\RequestBuilder\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/EffectsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\EffectsRequestBuilder\:\:limit\(\) should return Soneso\\StellarSDK\\Requests\\EffectsRequestBuilder but returns Soneso\\StellarSDK\\Requests\\RequestBuilder\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/EffectsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\EffectsRequestBuilder\:\:order\(\) should return Soneso\\StellarSDK\\Requests\\EffectsRequestBuilder but returns Soneso\\StellarSDK\\Requests\\RequestBuilder\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/EffectsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\EffectsRequestBuilder\:\:request\(\) should return Soneso\\StellarSDK\\Responses\\Effects\\EffectsPageResponse but returns Soneso\\StellarSDK\\Responses\\Response\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/EffectsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\EffectsRequestBuilder\:\:stream\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: Soneso/StellarSDK/Requests/EffectsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\FeeStatsRequestBuilder\:\:getFeeStats\(\) should return Soneso\\StellarSDK\\Responses\\FeeStats\\FeeStatsResponse but returns Soneso\\StellarSDK\\Responses\\Response\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/FeeStatsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\FindPathsRequestBuilder\:\:cursor\(\) should return Soneso\\StellarSDK\\Requests\\FindPathsRequestBuilder but returns Soneso\\StellarSDK\\Requests\\RequestBuilder\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/FindPathsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\FindPathsRequestBuilder\:\:limit\(\) should return Soneso\\StellarSDK\\Requests\\FindPathsRequestBuilder but returns Soneso\\StellarSDK\\Requests\\RequestBuilder\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/FindPathsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\FindPathsRequestBuilder\:\:order\(\) should return Soneso\\StellarSDK\\Requests\\FindPathsRequestBuilder but returns Soneso\\StellarSDK\\Requests\\RequestBuilder\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/FindPathsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\FindPathsRequestBuilder\:\:request\(\) should return Soneso\\StellarSDK\\Responses\\PaymentPath\\PathsPageResponse but returns Soneso\\StellarSDK\\Responses\\Response\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/FindPathsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\HealthRequestBuilder\:\:getHealth\(\) should return Soneso\\StellarSDK\\Responses\\Health\\HealthResponse but returns Soneso\\StellarSDK\\Responses\\Response\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/HealthRequestBuilder.php
+
+		-
+			message: '#^Deprecated in PHP 8\.4\: Parameter \#1 \$callback \(callable\) is implicitly nullable via default value null\.$#'
+			identifier: parameter.implicitlyNullable
+			count: 1
+			path: Soneso/StellarSDK/Requests/LedgersRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\LedgersRequestBuilder\:\:cursor\(\) should return Soneso\\StellarSDK\\Requests\\LedgersRequestBuilder but returns Soneso\\StellarSDK\\Requests\\RequestBuilder\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/LedgersRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\LedgersRequestBuilder\:\:ledger\(\) should return Soneso\\StellarSDK\\Responses\\Ledger\\LedgerResponse but returns Soneso\\StellarSDK\\Responses\\Response\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/LedgersRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\LedgersRequestBuilder\:\:limit\(\) should return Soneso\\StellarSDK\\Requests\\LedgersRequestBuilder but returns Soneso\\StellarSDK\\Requests\\RequestBuilder\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/LedgersRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\LedgersRequestBuilder\:\:order\(\) should return Soneso\\StellarSDK\\Requests\\LedgersRequestBuilder but returns Soneso\\StellarSDK\\Requests\\RequestBuilder\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/LedgersRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\LedgersRequestBuilder\:\:request\(\) should return Soneso\\StellarSDK\\Responses\\Ledger\\LedgersPageResponse but returns Soneso\\StellarSDK\\Responses\\Response\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/LedgersRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\LedgersRequestBuilder\:\:stream\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: Soneso/StellarSDK/Requests/LedgersRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\LiquidityPoolsRequestBuilder\:\:cursor\(\) should return Soneso\\StellarSDK\\Requests\\LiquidityPoolsRequestBuilder but returns Soneso\\StellarSDK\\Requests\\RequestBuilder\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/LiquidityPoolsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\LiquidityPoolsRequestBuilder\:\:forPoolId\(\) should return Soneso\\StellarSDK\\Responses\\LiquidityPools\\LiquidityPoolResponse but returns Soneso\\StellarSDK\\Responses\\Response\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/LiquidityPoolsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\LiquidityPoolsRequestBuilder\:\:limit\(\) should return Soneso\\StellarSDK\\Requests\\LiquidityPoolsRequestBuilder but returns Soneso\\StellarSDK\\Requests\\RequestBuilder\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/LiquidityPoolsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\LiquidityPoolsRequestBuilder\:\:order\(\) should return Soneso\\StellarSDK\\Requests\\LiquidityPoolsRequestBuilder but returns Soneso\\StellarSDK\\Requests\\RequestBuilder\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/LiquidityPoolsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\LiquidityPoolsRequestBuilder\:\:request\(\) should return Soneso\\StellarSDK\\Responses\\LiquidityPools\\LiquidityPoolsPageResponse but returns Soneso\\StellarSDK\\Responses\\Response\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/LiquidityPoolsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\OffersRequestBuilder\:\:cursor\(\) should return Soneso\\StellarSDK\\Requests\\OffersRequestBuilder but returns Soneso\\StellarSDK\\Requests\\RequestBuilder\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/OffersRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\OffersRequestBuilder\:\:limit\(\) should return Soneso\\StellarSDK\\Requests\\OffersRequestBuilder but returns Soneso\\StellarSDK\\Requests\\RequestBuilder\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/OffersRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\OffersRequestBuilder\:\:offer\(\) should return Soneso\\StellarSDK\\Responses\\Offers\\OfferResponse but returns Soneso\\StellarSDK\\Responses\\Response\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/OffersRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\OffersRequestBuilder\:\:order\(\) should return Soneso\\StellarSDK\\Requests\\OffersRequestBuilder but returns Soneso\\StellarSDK\\Requests\\RequestBuilder\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/OffersRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\OffersRequestBuilder\:\:request\(\) should return Soneso\\StellarSDK\\Responses\\Offers\\OffersPageResponse but returns Soneso\\StellarSDK\\Responses\\Response\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/OffersRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\OffersRequestBuilder\:\:stream\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: Soneso/StellarSDK/Requests/OffersRequestBuilder.php
+
+		-
+			message: '#^Deprecated in PHP 8\.4\: Parameter \#1 \$callback \(callable\) is implicitly nullable via default value null\.$#'
+			identifier: parameter.implicitlyNullable
+			count: 1
+			path: Soneso/StellarSDK/Requests/OperationsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\OperationsRequestBuilder\:\:cursor\(\) should return Soneso\\StellarSDK\\Requests\\OperationsRequestBuilder but returns Soneso\\StellarSDK\\Requests\\RequestBuilder\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/OperationsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\OperationsRequestBuilder\:\:limit\(\) should return Soneso\\StellarSDK\\Requests\\OperationsRequestBuilder but returns Soneso\\StellarSDK\\Requests\\RequestBuilder\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/OperationsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\OperationsRequestBuilder\:\:operation\(\) should return Soneso\\StellarSDK\\Responses\\Operations\\OperationResponse but returns Soneso\\StellarSDK\\Responses\\Response\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/OperationsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\OperationsRequestBuilder\:\:order\(\) should return Soneso\\StellarSDK\\Requests\\OperationsRequestBuilder but returns Soneso\\StellarSDK\\Requests\\RequestBuilder\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/OperationsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\OperationsRequestBuilder\:\:request\(\) should return Soneso\\StellarSDK\\Responses\\Operations\\OperationsPageResponse but returns Soneso\\StellarSDK\\Responses\\Response\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/OperationsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\OrderBookRequestBuilder\:\:cursor\(\) should return Soneso\\StellarSDK\\Requests\\OrderBookRequestBuilder but returns Soneso\\StellarSDK\\Requests\\RequestBuilder\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/OrderBookRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\OrderBookRequestBuilder\:\:limit\(\) should return Soneso\\StellarSDK\\Requests\\OrderBookRequestBuilder but returns Soneso\\StellarSDK\\Requests\\RequestBuilder\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/OrderBookRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\OrderBookRequestBuilder\:\:order\(\) should return Soneso\\StellarSDK\\Requests\\OrderBookRequestBuilder but returns Soneso\\StellarSDK\\Requests\\RequestBuilder\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/OrderBookRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\OrderBookRequestBuilder\:\:request\(\) should return Soneso\\StellarSDK\\Responses\\OrderBook\\OrderBookResponse but returns Soneso\\StellarSDK\\Responses\\Response\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/OrderBookRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\OrderBookRequestBuilder\:\:stream\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: Soneso/StellarSDK/Requests/OrderBookRequestBuilder.php
+
+		-
+			message: '#^Deprecated in PHP 8\.4\: Parameter \#1 \$callback \(callable\) is implicitly nullable via default value null\.$#'
+			identifier: parameter.implicitlyNullable
+			count: 1
+			path: Soneso/StellarSDK/Requests/PaymentsRequestBuilder.php
+
+		-
+			message: '#^Match expression does not handle remaining value\: mixed$#'
+			identifier: match.unhandled
+			count: 1
+			path: Soneso/StellarSDK/Requests/PaymentsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\PaymentsRequestBuilder\:\:cursor\(\) should return Soneso\\StellarSDK\\Requests\\PaymentsRequestBuilder but returns Soneso\\StellarSDK\\Requests\\RequestBuilder\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/PaymentsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\PaymentsRequestBuilder\:\:limit\(\) should return Soneso\\StellarSDK\\Requests\\PaymentsRequestBuilder but returns Soneso\\StellarSDK\\Requests\\RequestBuilder\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/PaymentsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\PaymentsRequestBuilder\:\:order\(\) should return Soneso\\StellarSDK\\Requests\\PaymentsRequestBuilder but returns Soneso\\StellarSDK\\Requests\\RequestBuilder\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/PaymentsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\PaymentsRequestBuilder\:\:request\(\) should return Soneso\\StellarSDK\\Responses\\Operations\\OperationsPageResponse but returns Soneso\\StellarSDK\\Responses\\Response\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/PaymentsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\PaymentsRequestBuilder\:\:stream\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: Soneso/StellarSDK/Requests/PaymentsRequestBuilder.php
+
+		-
+			message: '#^Parameter \#3 \$e of static method Soneso\\StellarSDK\\Exceptions\\HorizonRequestException\:\:fromOtherException\(\) expects Exception, GuzzleHttp\\Exception\\GuzzleException given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/RequestBuilder.php
+
+		-
+			message: '#^Property Soneso\\StellarSDK\\Requests\\RequestBuilder\:\:\$queryParameters type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Requests/RequestBuilder.php
+
+		-
+			message: '#^Property Soneso\\StellarSDK\\Requests\\RequestBuilder\:\:\$segments type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Requests/RequestBuilder.php
+
+		-
+			message: '#^While loop condition is always true\.$#'
+			identifier: while.alwaysTrue
+			count: 1
+			path: Soneso/StellarSDK/Requests/RequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\RootRequestBuilder\:\:getRoot\(\) should return Soneso\\StellarSDK\\Responses\\Root\\RootResponse but returns Soneso\\StellarSDK\\Responses\\Response\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/RootRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\StrictReceivePathsRequestBuilder\:\:cursor\(\) should return Soneso\\StellarSDK\\Requests\\StrictReceivePathsRequestBuilder but returns Soneso\\StellarSDK\\Requests\\RequestBuilder\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/StrictReceivePathsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\StrictReceivePathsRequestBuilder\:\:forSourceAssets\(\) has parameter \$assets with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Requests/StrictReceivePathsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\StrictReceivePathsRequestBuilder\:\:limit\(\) should return Soneso\\StellarSDK\\Requests\\StrictReceivePathsRequestBuilder but returns Soneso\\StellarSDK\\Requests\\RequestBuilder\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/StrictReceivePathsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\StrictReceivePathsRequestBuilder\:\:order\(\) should return Soneso\\StellarSDK\\Requests\\StrictReceivePathsRequestBuilder but returns Soneso\\StellarSDK\\Requests\\RequestBuilder\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/StrictReceivePathsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\StrictReceivePathsRequestBuilder\:\:request\(\) should return Soneso\\StellarSDK\\Responses\\PaymentPath\\PathsPageResponse but returns Soneso\\StellarSDK\\Responses\\Response\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/StrictReceivePathsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\StrictSendPathsRequestBuilder\:\:cursor\(\) should return Soneso\\StellarSDK\\Requests\\StrictSendPathsRequestBuilder but returns Soneso\\StellarSDK\\Requests\\RequestBuilder\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/StrictSendPathsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\StrictSendPathsRequestBuilder\:\:forDestinationAssets\(\) has parameter \$assets with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Requests/StrictSendPathsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\StrictSendPathsRequestBuilder\:\:limit\(\) should return Soneso\\StellarSDK\\Requests\\StrictSendPathsRequestBuilder but returns Soneso\\StellarSDK\\Requests\\RequestBuilder\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/StrictSendPathsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\StrictSendPathsRequestBuilder\:\:order\(\) should return Soneso\\StellarSDK\\Requests\\StrictSendPathsRequestBuilder but returns Soneso\\StellarSDK\\Requests\\RequestBuilder\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/StrictSendPathsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\StrictSendPathsRequestBuilder\:\:request\(\) should return Soneso\\StellarSDK\\Responses\\PaymentPath\\PathsPageResponse but returns Soneso\\StellarSDK\\Responses\\Response\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/StrictSendPathsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\TradeAggregationsRequestBuilder\:\:cursor\(\) should return Soneso\\StellarSDK\\Requests\\TradeAggregationsRequestBuilder but returns Soneso\\StellarSDK\\Requests\\RequestBuilder\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/TradeAggregationsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\TradeAggregationsRequestBuilder\:\:limit\(\) should return Soneso\\StellarSDK\\Requests\\TradeAggregationsRequestBuilder but returns Soneso\\StellarSDK\\Requests\\RequestBuilder\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/TradeAggregationsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\TradeAggregationsRequestBuilder\:\:order\(\) should return Soneso\\StellarSDK\\Requests\\TradeAggregationsRequestBuilder but returns Soneso\\StellarSDK\\Requests\\RequestBuilder\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/TradeAggregationsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\TradeAggregationsRequestBuilder\:\:request\(\) should return Soneso\\StellarSDK\\Responses\\TradeAggregations\\TradeAggregationsPageResponse but returns Soneso\\StellarSDK\\Responses\\Response\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/TradeAggregationsRequestBuilder.php
+
+		-
+			message: '#^Constant Soneso\\StellarSDK\\Requests\\TradesRequestBuilder\:\:TRADE_TYPE_ALL is unused\.$#'
+			identifier: classConstant.unused
+			count: 1
+			path: Soneso/StellarSDK/Requests/TradesRequestBuilder.php
+
+		-
+			message: '#^Constant Soneso\\StellarSDK\\Requests\\TradesRequestBuilder\:\:TRADE_TYPE_LIQUIDITY_POOLS is unused\.$#'
+			identifier: classConstant.unused
+			count: 1
+			path: Soneso/StellarSDK/Requests/TradesRequestBuilder.php
+
+		-
+			message: '#^Constant Soneso\\StellarSDK\\Requests\\TradesRequestBuilder\:\:TRADE_TYPE_ORDERBOOK is unused\.$#'
+			identifier: classConstant.unused
+			count: 1
+			path: Soneso/StellarSDK/Requests/TradesRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\TradesRequestBuilder\:\:cursor\(\) should return Soneso\\StellarSDK\\Requests\\TradesRequestBuilder but returns Soneso\\StellarSDK\\Requests\\RequestBuilder\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/TradesRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\TradesRequestBuilder\:\:limit\(\) should return Soneso\\StellarSDK\\Requests\\TradesRequestBuilder but returns Soneso\\StellarSDK\\Requests\\RequestBuilder\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/TradesRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\TradesRequestBuilder\:\:order\(\) should return Soneso\\StellarSDK\\Requests\\TradesRequestBuilder but returns Soneso\\StellarSDK\\Requests\\RequestBuilder\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/TradesRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\TradesRequestBuilder\:\:request\(\) should return Soneso\\StellarSDK\\Responses\\Trades\\TradesPageResponse but returns Soneso\\StellarSDK\\Responses\\Response\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/TradesRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\TradesRequestBuilder\:\:stream\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: Soneso/StellarSDK/Requests/TradesRequestBuilder.php
+
+		-
+			message: '#^Deprecated in PHP 8\.4\: Parameter \#1 \$callback \(callable\) is implicitly nullable via default value null\.$#'
+			identifier: parameter.implicitlyNullable
+			count: 1
+			path: Soneso/StellarSDK/Requests/TransactionsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\TransactionsRequestBuilder\:\:cursor\(\) should return Soneso\\StellarSDK\\Requests\\TransactionsRequestBuilder but returns Soneso\\StellarSDK\\Requests\\RequestBuilder\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/TransactionsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\TransactionsRequestBuilder\:\:limit\(\) should return Soneso\\StellarSDK\\Requests\\TransactionsRequestBuilder but returns Soneso\\StellarSDK\\Requests\\RequestBuilder\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/TransactionsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\TransactionsRequestBuilder\:\:order\(\) should return Soneso\\StellarSDK\\Requests\\TransactionsRequestBuilder but returns Soneso\\StellarSDK\\Requests\\RequestBuilder\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/TransactionsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\TransactionsRequestBuilder\:\:request\(\) should return Soneso\\StellarSDK\\Responses\\Transaction\\TransactionsPageResponse but returns Soneso\\StellarSDK\\Responses\\Response\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/TransactionsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Requests\\TransactionsRequestBuilder\:\:transaction\(\) should return Soneso\\StellarSDK\\Responses\\Transaction\\TransactionResponse but returns Soneso\\StellarSDK\\Responses\\Response\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Requests/TransactionsRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Account\\AccountBalanceResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Account/AccountBalanceResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Account\\AccountBalanceResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Account/AccountBalanceResponse.php
+
+		-
+			message: '#^Call to an undefined method Iterator\<mixed, mixed\>\:\:append\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Soneso/StellarSDK/Responses/Account/AccountBalancesResponse.php
+
+		-
+			message: '#^Call to an undefined method Iterator\<mixed, mixed\>\:\:count\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Soneso/StellarSDK/Responses/Account/AccountBalancesResponse.php
+
+		-
+			message: '#^Class Soneso\\StellarSDK\\Responses\\Account\\AccountBalancesResponse extends generic class IteratorIterator but does not specify its types\: TKey, TValue, TIterator$#'
+			identifier: missingType.generics
+			count: 1
+			path: Soneso/StellarSDK/Responses/Account/AccountBalancesResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Account\\AccountBalancesResponse\:\:add\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: Soneso/StellarSDK/Responses/Account/AccountBalancesResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Account\\AccountDataResponse\:\:__construct\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Account/AccountDataResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Account\\AccountDataResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Account/AccountDataResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Account\\AccountDataResponse\:\:getData\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Account/AccountDataResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Account\\AccountDataResponse\:\:getKeys\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Account/AccountDataResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Account\\AccountDataValueResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Account/AccountDataValueResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Account\\AccountFlagsResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Account/AccountFlagsResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Account\\AccountFlagsResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Account/AccountFlagsResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Account\\AccountLinksResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Account/AccountLinksResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Account\\AccountLinksResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Account/AccountLinksResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Account\\AccountResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Account/AccountResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Account\\AccountResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Account/AccountResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Account\\AccountSignerResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Account/AccountSignerResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Account\\AccountSignerResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Account/AccountSignerResponse.php
+
+		-
+			message: '#^Call to an undefined method Iterator\<mixed, mixed\>\:\:append\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Soneso/StellarSDK/Responses/Account/AccountSignersResponse.php
+
+		-
+			message: '#^Call to an undefined method Iterator\<mixed, mixed\>\:\:count\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Soneso/StellarSDK/Responses/Account/AccountSignersResponse.php
+
+		-
+			message: '#^Class Soneso\\StellarSDK\\Responses\\Account\\AccountSignersResponse extends generic class IteratorIterator but does not specify its types\: TKey, TValue, TIterator$#'
+			identifier: missingType.generics
+			count: 1
+			path: Soneso/StellarSDK/Responses/Account/AccountSignersResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Account\\AccountSignersResponse\:\:add\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: Soneso/StellarSDK/Responses/Account/AccountSignersResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Account\\AccountThresholdsResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Account/AccountThresholdsResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Account\\AccountThresholdsResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Account/AccountThresholdsResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Account\\AccountsPageResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Account/AccountsPageResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Account\\AccountsPageResponse\:\:getNextPage\(\) should return Soneso\\StellarSDK\\Responses\\Account\\AccountsPageResponse\|null but returns Soneso\\StellarSDK\\Responses\\Response\|null\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Responses/Account/AccountsPageResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Account\\AccountsPageResponse\:\:getPreviousPage\(\) should return Soneso\\StellarSDK\\Responses\\Account\\AccountsPageResponse\|null but returns Soneso\\StellarSDK\\Responses\\Response\|null\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Responses/Account/AccountsPageResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Account\\AccountsPageResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Account/AccountsPageResponse.php
+
+		-
+			message: '#^Call to an undefined method Iterator\<mixed, mixed\>\:\:append\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Soneso/StellarSDK/Responses/Account/AccountsResponse.php
+
+		-
+			message: '#^Call to an undefined method Iterator\<mixed, mixed\>\:\:count\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Soneso/StellarSDK/Responses/Account/AccountsResponse.php
+
+		-
+			message: '#^Class Soneso\\StellarSDK\\Responses\\Account\\AccountsResponse extends generic class IteratorIterator but does not specify its types\: TKey, TValue, TIterator$#'
+			identifier: missingType.generics
+			count: 1
+			path: Soneso/StellarSDK/Responses/Account/AccountsResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Account\\AccountsResponse\:\:add\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: Soneso/StellarSDK/Responses/Account/AccountsResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Asset\\AssetAccountsResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Asset/AssetAccountsResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Asset\\AssetAccountsResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Asset/AssetAccountsResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Asset\\AssetBalancesResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Asset/AssetBalancesResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Asset\\AssetBalancesResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Asset/AssetBalancesResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Asset\\AssetFlagsResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Asset/AssetFlagsResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Asset\\AssetFlagsResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Asset/AssetFlagsResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Asset\\AssetLinksResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Asset/AssetLinksResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Asset\\AssetLinksResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Asset/AssetLinksResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Asset\\AssetResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Asset/AssetResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Asset\\AssetResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Asset/AssetResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Asset\\AssetsPageResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Asset/AssetsPageResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Asset\\AssetsPageResponse\:\:getNextPage\(\) should return Soneso\\StellarSDK\\Responses\\Asset\\AssetsPageResponse\|null but returns Soneso\\StellarSDK\\Responses\\Response\|null\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Responses/Asset/AssetsPageResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Asset\\AssetsPageResponse\:\:getPreviousPage\(\) should return Soneso\\StellarSDK\\Responses\\Asset\\AssetsPageResponse\|null but returns Soneso\\StellarSDK\\Responses\\Response\|null\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Responses/Asset/AssetsPageResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Asset\\AssetsPageResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Asset/AssetsPageResponse.php
+
+		-
+			message: '#^Call to an undefined method Iterator\<mixed, mixed\>\:\:append\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Soneso/StellarSDK/Responses/Asset/AssetsResponse.php
+
+		-
+			message: '#^Call to an undefined method Iterator\<mixed, mixed\>\:\:count\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Soneso/StellarSDK/Responses/Asset/AssetsResponse.php
+
+		-
+			message: '#^Class Soneso\\StellarSDK\\Responses\\Asset\\AssetsResponse extends generic class IteratorIterator but does not specify its types\: TKey, TValue, TIterator$#'
+			identifier: missingType.generics
+			count: 1
+			path: Soneso/StellarSDK/Responses/Asset/AssetsResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\ClaimableBalances\\ClaimableBalanceLinksResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/ClaimableBalances/ClaimableBalanceLinksResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\ClaimableBalances\\ClaimableBalanceLinksResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/ClaimableBalances/ClaimableBalanceLinksResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\ClaimableBalances\\ClaimableBalanceResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/ClaimableBalances/ClaimableBalanceResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\ClaimableBalances\\ClaimableBalanceResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/ClaimableBalances/ClaimableBalanceResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\ClaimableBalances\\ClaimableBalancesPageResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/ClaimableBalances/ClaimableBalancesPageResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\ClaimableBalances\\ClaimableBalancesPageResponse\:\:getNextPage\(\) should return Soneso\\StellarSDK\\Responses\\ClaimableBalances\\ClaimableBalancesPageResponse\|null but returns Soneso\\StellarSDK\\Responses\\Response\|null\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Responses/ClaimableBalances/ClaimableBalancesPageResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\ClaimableBalances\\ClaimableBalancesPageResponse\:\:getPreviousPage\(\) should return Soneso\\StellarSDK\\Responses\\ClaimableBalances\\ClaimableBalancesPageResponse\|null but returns Soneso\\StellarSDK\\Responses\\Response\|null\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Responses/ClaimableBalances/ClaimableBalancesPageResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\ClaimableBalances\\ClaimableBalancesPageResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/ClaimableBalances/ClaimableBalancesPageResponse.php
+
+		-
+			message: '#^Call to an undefined method Iterator\<mixed, mixed\>\:\:append\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Soneso/StellarSDK/Responses/ClaimableBalances/ClaimableBalancesResponse.php
+
+		-
+			message: '#^Call to an undefined method Iterator\<mixed, mixed\>\:\:count\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Soneso/StellarSDK/Responses/ClaimableBalances/ClaimableBalancesResponse.php
+
+		-
+			message: '#^Class Soneso\\StellarSDK\\Responses\\ClaimableBalances\\ClaimableBalancesResponse extends generic class IteratorIterator but does not specify its types\: TKey, TValue, TIterator$#'
+			identifier: missingType.generics
+			count: 1
+			path: Soneso/StellarSDK/Responses/ClaimableBalances/ClaimableBalancesResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\ClaimableBalances\\ClaimantPredicateResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/ClaimableBalances/ClaimantPredicateResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\ClaimableBalances\\ClaimantPredicateResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/ClaimableBalances/ClaimantPredicateResponse.php
+
+		-
+			message: '#^Call to an undefined method Iterator\<mixed, mixed\>\:\:append\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Soneso/StellarSDK/Responses/ClaimableBalances/ClaimantPredicatesResponse.php
+
+		-
+			message: '#^Call to an undefined method Iterator\<mixed, mixed\>\:\:count\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Soneso/StellarSDK/Responses/ClaimableBalances/ClaimantPredicatesResponse.php
+
+		-
+			message: '#^Class Soneso\\StellarSDK\\Responses\\ClaimableBalances\\ClaimantPredicatesResponse extends generic class IteratorIterator but does not specify its types\: TKey, TValue, TIterator$#'
+			identifier: missingType.generics
+			count: 1
+			path: Soneso/StellarSDK/Responses/ClaimableBalances/ClaimantPredicatesResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\ClaimableBalances\\ClaimantResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/ClaimableBalances/ClaimantResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\ClaimableBalances\\ClaimantResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/ClaimableBalances/ClaimantResponse.php
+
+		-
+			message: '#^Call to an undefined method Iterator\<mixed, mixed\>\:\:append\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Soneso/StellarSDK/Responses/ClaimableBalances/ClaimantsResponse.php
+
+		-
+			message: '#^Call to an undefined method Iterator\<mixed, mixed\>\:\:count\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Soneso/StellarSDK/Responses/ClaimableBalances/ClaimantsResponse.php
+
+		-
+			message: '#^Class Soneso\\StellarSDK\\Responses\\ClaimableBalances\\ClaimantsResponse extends generic class IteratorIterator but does not specify its types\: TKey, TValue, TIterator$#'
+			identifier: missingType.generics
+			count: 1
+			path: Soneso/StellarSDK/Responses/ClaimableBalances/ClaimantsResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\AccountCreatedEffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/AccountCreatedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\AccountCreatedEffectResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/AccountCreatedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\AccountCreditedEffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/AccountCreditedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\AccountCreditedEffectResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/AccountCreditedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\AccountDebitedEffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/AccountDebitedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\AccountDebitedEffectResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/AccountDebitedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\AccountFlagsUpdatedEffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/AccountFlagsUpdatedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\AccountFlagsUpdatedEffectResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/AccountFlagsUpdatedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\AccountHomeDomainUpdatedEffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/AccountHomeDomainUpdatedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\AccountHomeDomainUpdatedEffectResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/AccountHomeDomainUpdatedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\AccountInflationDestinationUpdatedEffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/AccountInflationDestinationUpdatedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\AccountRemovedEffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/AccountRemovedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\AccountSponsorshipCreatedEffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/AccountSponsorshipCreatedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\AccountSponsorshipCreatedEffectResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/AccountSponsorshipCreatedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\AccountSponsorshipRemovedEffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/AccountSponsorshipRemovedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\AccountSponsorshipRemovedEffectResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/AccountSponsorshipRemovedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\AccountSponsorshipUpdatedEffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/AccountSponsorshipUpdatedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\AccountSponsorshipUpdatedEffectResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/AccountSponsorshipUpdatedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\AccountThresholdsUpdatedEffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/AccountThresholdsUpdatedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\AccountThresholdsUpdatedEffectResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/AccountThresholdsUpdatedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\ClaimableBalanceClaimantCreatedEffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/ClaimableBalanceClaimantCreatedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\ClaimableBalanceClaimantCreatedEffectResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/ClaimableBalanceClaimantCreatedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\ClaimableBalanceClaimedEffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/ClaimableBalanceClaimedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\ClaimableBalanceClaimedEffectResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/ClaimableBalanceClaimedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\ClaimableBalanceClawedBackEffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/ClaimableBalanceClawedBackEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\ClaimableBalanceClawedBackEffectResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/ClaimableBalanceClawedBackEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\ClaimableBalanceCreatedEffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/ClaimableBalanceCreatedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\ClaimableBalanceCreatedEffectResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/ClaimableBalanceCreatedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\ClaimableBalanceSponsorshipCreatedEffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/ClaimableBalanceSponsorshipCreatedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\ClaimableBalanceSponsorshipCreatedEffectResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/ClaimableBalanceSponsorshipCreatedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\ClaimableBalanceSponsorshipRemovedEffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/ClaimableBalanceSponsorshipRemovedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\ClaimableBalanceSponsorshipRemovedEffectResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/ClaimableBalanceSponsorshipRemovedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\ClaimableBalanceSponsorshipUpdatedEffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/ClaimableBalanceSponsorshipUpdatedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\ClaimableBalanceSponsorshipUpdatedEffectResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/ClaimableBalanceSponsorshipUpdatedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\ContractCreditedEffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/ContractCreditedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\ContractCreditedEffectResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/ContractCreditedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\ContractDebitedEffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/ContractDebitedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\ContractDebitedEffectResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/ContractDebitedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\DataCreatedEffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/DataCreatedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\DataCreatedEffectResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/DataCreatedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\DataRemovedEffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/DataRemovedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\DataRemovedEffectResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/DataRemovedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\DataSponsorshipCreatedEffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/DataSponsorshipCreatedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\DataSponsorshipCreatedEffectResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/DataSponsorshipCreatedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\DataSponsorshipRemovedEffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/DataSponsorshipRemovedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\DataSponsorshipRemovedEffectResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/DataSponsorshipRemovedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\DataSponsorshipUpdatedEffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/DataSponsorshipUpdatedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\DataSponsorshipUpdatedEffectResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/DataSponsorshipUpdatedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\DataUpdatedEffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/DataUpdatedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\DataUpdatedEffectResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/DataUpdatedEffectResponse.php
+
+		-
+			message: '#^Access to an undefined property Soneso\\StellarSDK\\Responses\\Effects\\EffectLinksResponse\:\:\$effects\.$#'
+			identifier: property.notFound
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/EffectLinksResponse.php
+
+		-
+			message: '#^Access to an undefined property Soneso\\StellarSDK\\Responses\\Effects\\EffectLinksResponse\:\:\$self\.$#'
+			identifier: property.notFound
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/EffectLinksResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\EffectLinksResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/EffectLinksResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\EffectLinksResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/EffectLinksResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\EffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/EffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\EffectResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/EffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\EffectsPageResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/EffectsPageResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\EffectsPageResponse\:\:getNextPage\(\) should return Soneso\\StellarSDK\\Responses\\Effects\\EffectsPageResponse\|null but returns Soneso\\StellarSDK\\Responses\\Response\|null\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/EffectsPageResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\EffectsPageResponse\:\:getPreviousPage\(\) should return Soneso\\StellarSDK\\Responses\\Effects\\EffectsPageResponse\|null but returns Soneso\\StellarSDK\\Responses\\Response\|null\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/EffectsPageResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\EffectsPageResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/EffectsPageResponse.php
+
+		-
+			message: '#^Call to an undefined method Iterator\<mixed, mixed\>\:\:append\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/EffectsResponse.php
+
+		-
+			message: '#^Call to an undefined method Iterator\<mixed, mixed\>\:\:count\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/EffectsResponse.php
+
+		-
+			message: '#^Class Soneso\\StellarSDK\\Responses\\Effects\\EffectsResponse extends generic class IteratorIterator but does not specify its types\: TKey, TValue, TIterator$#'
+			identifier: missingType.generics
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/EffectsResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\LiquidityPoolCreatedEffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/LiquidityPoolCreatedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\LiquidityPoolCreatedEffectResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/LiquidityPoolCreatedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\LiquidityPoolDepositedEffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/LiquidityPoolDepositedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\LiquidityPoolDepositedEffectResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/LiquidityPoolDepositedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\LiquidityPoolEffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/LiquidityPoolEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\LiquidityPoolEffectResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/LiquidityPoolEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\LiquidityPoolRemovedEffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/LiquidityPoolRemovedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\LiquidityPoolRemovedEffectResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/LiquidityPoolRemovedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\LiquidityPoolRevokedEffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/LiquidityPoolRevokedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\LiquidityPoolRevokedEffectResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/LiquidityPoolRevokedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\LiquidityPoolTradeEffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/LiquidityPoolTradeEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\LiquidityPoolTradeEffectResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/LiquidityPoolTradeEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\LiquidityPoolWithdrewEffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/LiquidityPoolWithdrewEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\LiquidityPoolWithdrewEffectResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/LiquidityPoolWithdrewEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\OfferCreatedEffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/OfferCreatedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\OfferRemovedEffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/OfferRemovedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\OfferUpdatedEffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/OfferUpdatedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\SequenceBumpedEffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/SequenceBumpedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\SequenceBumpedEffectResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/SequenceBumpedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\SignerCreatedEffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/SignerCreatedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\SignerEffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/SignerEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\SignerEffectResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/SignerEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\SignerRemovedEffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/SignerRemovedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\SignerSponsorshipCreatedEffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/SignerSponsorshipCreatedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\SignerSponsorshipCreatedEffectResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/SignerSponsorshipCreatedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\SignerSponsorshipRemovedEffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/SignerSponsorshipRemovedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\SignerSponsorshipRemovedEffectResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/SignerSponsorshipRemovedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\SignerSponsorshipUpdatedEffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/SignerSponsorshipUpdatedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\SignerSponsorshipUpdatedEffectResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/SignerSponsorshipUpdatedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\SignerUpdatedEffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/SignerUpdatedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\TradeEffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/TradeEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\TradeEffectResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/TradeEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\TrustlineAuthorizedEffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/TrustlineAuthorizedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\TrustlineAuthorizedToMaintainLiabilitiesEffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/TrustlineAuthorizedToMaintainLiabilitiesEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\TrustlineCreatedEffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/TrustlineCreatedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\TrustlineDeauthorizedEffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/TrustlineDeauthorizedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\TrustlineEffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/TrustlineEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\TrustlineEffectResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/TrustlineEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\TrustlineFlagsUpdatedEffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/TrustlineFlagsUpdatedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\TrustlineFlagsUpdatedEffectResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/TrustlineFlagsUpdatedEffectResponse.php
+
+		-
+			message: '#^Property Soneso\\StellarSDK\\Responses\\Effects\\TrustlineFlagsUpdatedEffectResponse\:\:\$authorizedFlag \(bool\|null\) is never assigned null so it can be removed from the property type\.$#'
+			identifier: property.unusedType
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/TrustlineFlagsUpdatedEffectResponse.php
+
+		-
+			message: '#^Property Soneso\\StellarSDK\\Responses\\Effects\\TrustlineFlagsUpdatedEffectResponse\:\:\$authorizedToMaintainLiabilitiesFlag \(bool\|null\) is never assigned null so it can be removed from the property type\.$#'
+			identifier: property.unusedType
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/TrustlineFlagsUpdatedEffectResponse.php
+
+		-
+			message: '#^Property Soneso\\StellarSDK\\Responses\\Effects\\TrustlineFlagsUpdatedEffectResponse\:\:\$clawbackEnabledFlag \(bool\|null\) is never assigned null so it can be removed from the property type\.$#'
+			identifier: property.unusedType
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/TrustlineFlagsUpdatedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\TrustlineRemovedEffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/TrustlineRemovedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\TrustlineSponsorshipCreatedEffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/TrustlineSponsorshipCreatedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\TrustlineSponsorshipCreatedEffectResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/TrustlineSponsorshipCreatedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\TrustlineSponsorshipRemovedEffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/TrustlineSponsorshipRemovedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\TrustlineSponsorshipRemovedEffectResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/TrustlineSponsorshipRemovedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\TrustlineSponsorshipUpdatedEffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/TrustlineSponsorshipUpdatedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\TrustlineSponsorshipUpdatedEffectResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/TrustlineSponsorshipUpdatedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Effects\\TrustlineUpdatedEffectResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Effects/TrustlineUpdatedEffectResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Errors\\HorizonErrorResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Errors/HorizonErrorResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Errors\\HorizonErrorResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Errors/HorizonErrorResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Errors\\HorizonErrorResponseExtras\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Errors/HorizonErrorResponseExtras.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Errors\\HorizonErrorResponseExtras\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Errors/HorizonErrorResponseExtras.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\FeeStats\\FeeChargedResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/FeeStats/FeeChargedResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\FeeStats\\FeeChargedResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/FeeStats/FeeChargedResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\FeeStats\\FeeStatsResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/FeeStats/FeeStatsResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\FeeStats\\FeeStatsResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/FeeStats/FeeStatsResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\FeeStats\\MaxFeeResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/FeeStats/MaxFeeResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\FeeStats\\MaxFeeResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/FeeStats/MaxFeeResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Health\\HealthResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Health/HealthResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Health\\HealthResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Health/HealthResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Ledger\\LedgerLinksResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Ledger/LedgerLinksResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Ledger\\LedgerLinksResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Ledger/LedgerLinksResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Ledger\\LedgerResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Ledger/LedgerResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Ledger\\LedgerResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Ledger/LedgerResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Ledger\\LedgersPageResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Ledger/LedgersPageResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Ledger\\LedgersPageResponse\:\:getNextPage\(\) should return Soneso\\StellarSDK\\Responses\\Ledger\\LedgersPageResponse\|null but returns Soneso\\StellarSDK\\Responses\\Response\|null\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Responses/Ledger/LedgersPageResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Ledger\\LedgersPageResponse\:\:getPreviousPage\(\) should return Soneso\\StellarSDK\\Responses\\Ledger\\LedgersPageResponse\|null but returns Soneso\\StellarSDK\\Responses\\Response\|null\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Responses/Ledger/LedgersPageResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Ledger\\LedgersPageResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Ledger/LedgersPageResponse.php
+
+		-
+			message: '#^Call to an undefined method Iterator\<mixed, mixed\>\:\:append\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Soneso/StellarSDK/Responses/Ledger/LedgersResponse.php
+
+		-
+			message: '#^Call to an undefined method Iterator\<mixed, mixed\>\:\:count\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Soneso/StellarSDK/Responses/Ledger/LedgersResponse.php
+
+		-
+			message: '#^Class Soneso\\StellarSDK\\Responses\\Ledger\\LedgersResponse extends generic class IteratorIterator but does not specify its types\: TKey, TValue, TIterator$#'
+			identifier: missingType.generics
+			count: 1
+			path: Soneso/StellarSDK/Responses/Ledger/LedgersResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Link\\LinkResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Link/LinkResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Link\\LinkResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Link/LinkResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\LiquidityPools\\LiquidityPoolLinksResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/LiquidityPools/LiquidityPoolLinksResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\LiquidityPools\\LiquidityPoolLinksResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/LiquidityPools/LiquidityPoolLinksResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\LiquidityPools\\LiquidityPoolPriceResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/LiquidityPools/LiquidityPoolPriceResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\LiquidityPools\\LiquidityPoolPriceResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/LiquidityPools/LiquidityPoolPriceResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\LiquidityPools\\LiquidityPoolResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/LiquidityPools/LiquidityPoolResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\LiquidityPools\\LiquidityPoolResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/LiquidityPools/LiquidityPoolResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\LiquidityPools\\LiquidityPoolsPageResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/LiquidityPools/LiquidityPoolsPageResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\LiquidityPools\\LiquidityPoolsPageResponse\:\:getNextPage\(\) should return Soneso\\StellarSDK\\Responses\\LiquidityPools\\LiquidityPoolsPageResponse\|null but returns Soneso\\StellarSDK\\Responses\\Response\|null\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Responses/LiquidityPools/LiquidityPoolsPageResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\LiquidityPools\\LiquidityPoolsPageResponse\:\:getPreviousPage\(\) should return Soneso\\StellarSDK\\Responses\\LiquidityPools\\LiquidityPoolsPageResponse\|null but returns Soneso\\StellarSDK\\Responses\\Response\|null\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Responses/LiquidityPools/LiquidityPoolsPageResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\LiquidityPools\\LiquidityPoolsPageResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/LiquidityPools/LiquidityPoolsPageResponse.php
+
+		-
+			message: '#^Call to an undefined method Iterator\<mixed, mixed\>\:\:append\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Soneso/StellarSDK/Responses/LiquidityPools/LiquidityPoolsResponse.php
+
+		-
+			message: '#^Call to an undefined method Iterator\<mixed, mixed\>\:\:count\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Soneso/StellarSDK/Responses/LiquidityPools/LiquidityPoolsResponse.php
+
+		-
+			message: '#^Class Soneso\\StellarSDK\\Responses\\LiquidityPools\\LiquidityPoolsResponse extends generic class IteratorIterator but does not specify its types\: TKey, TValue, TIterator$#'
+			identifier: missingType.generics
+			count: 1
+			path: Soneso/StellarSDK/Responses/LiquidityPools/LiquidityPoolsResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\LiquidityPools\\ReserveResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/LiquidityPools/ReserveResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\LiquidityPools\\ReserveResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/LiquidityPools/ReserveResponse.php
+
+		-
+			message: '#^Call to an undefined method Iterator\<mixed, mixed\>\:\:append\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Soneso/StellarSDK/Responses/LiquidityPools/ReservesResponse.php
+
+		-
+			message: '#^Call to an undefined method Iterator\<mixed, mixed\>\:\:count\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Soneso/StellarSDK/Responses/LiquidityPools/ReservesResponse.php
+
+		-
+			message: '#^Class Soneso\\StellarSDK\\Responses\\LiquidityPools\\ReservesResponse extends generic class IteratorIterator but does not specify its types\: TKey, TValue, TIterator$#'
+			identifier: missingType.generics
+			count: 1
+			path: Soneso/StellarSDK/Responses/LiquidityPools/ReservesResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Offers\\OfferLinksResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Offers/OfferLinksResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Offers\\OfferLinksResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Offers/OfferLinksResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Offers\\OfferPriceResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Offers/OfferPriceResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Offers\\OfferPriceResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Offers/OfferPriceResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Offers\\OfferResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Offers/OfferResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Offers\\OfferResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Offers/OfferResponse.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between Soneso\\StellarSDK\\Asset and null will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 2
+			path: Soneso/StellarSDK/Responses/Offers/OfferResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Offers\\OffersPageResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Offers/OffersPageResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Offers\\OffersPageResponse\:\:getNextPage\(\) should return Soneso\\StellarSDK\\Responses\\Offers\\OffersPageResponse\|null but returns Soneso\\StellarSDK\\Responses\\Response\|null\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Responses/Offers/OffersPageResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Offers\\OffersPageResponse\:\:getPreviousPage\(\) should return Soneso\\StellarSDK\\Responses\\Offers\\OffersPageResponse\|null but returns Soneso\\StellarSDK\\Responses\\Response\|null\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Responses/Offers/OffersPageResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Offers\\OffersPageResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Offers/OffersPageResponse.php
+
+		-
+			message: '#^Call to an undefined method Iterator\<mixed, mixed\>\:\:append\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Soneso/StellarSDK/Responses/Offers/OffersResponse.php
+
+		-
+			message: '#^Call to an undefined method Iterator\<mixed, mixed\>\:\:count\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Soneso/StellarSDK/Responses/Offers/OffersResponse.php
+
+		-
+			message: '#^Class Soneso\\StellarSDK\\Responses\\Offers\\OffersResponse extends generic class IteratorIterator but does not specify its types\: TKey, TValue, TIterator$#'
+			identifier: missingType.generics
+			count: 1
+			path: Soneso/StellarSDK/Responses/Offers/OffersResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\AccountMergeOperationResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/AccountMergeOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\AccountMergeOperationResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/AccountMergeOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\AllowTrustOperationResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/AllowTrustOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\AllowTrustOperationResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/AllowTrustOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\AssetBalanceChangeResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/AssetBalanceChangeResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\AssetBalanceChangeResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/AssetBalanceChangeResponse.php
+
+		-
+			message: '#^Call to an undefined method Iterator\<mixed, mixed\>\:\:append\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/AssetBalanceChangesResponse.php
+
+		-
+			message: '#^Call to an undefined method Iterator\<mixed, mixed\>\:\:count\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/AssetBalanceChangesResponse.php
+
+		-
+			message: '#^Class Soneso\\StellarSDK\\Responses\\Operations\\AssetBalanceChangesResponse extends generic class IteratorIterator but does not specify its types\: TKey, TValue, TIterator$#'
+			identifier: missingType.generics
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/AssetBalanceChangesResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\BeginSponsoringFutureReservesOperationResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/BeginSponsoringFutureReservesOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\BeginSponsoringFutureReservesOperationResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/BeginSponsoringFutureReservesOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\BumpSequenceOperationResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/BumpSequenceOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\BumpSequenceOperationResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/BumpSequenceOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\ChangeTrustOperationResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/ChangeTrustOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\ChangeTrustOperationResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/ChangeTrustOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\ClaimClaimableBalanceOperationResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/ClaimClaimableBalanceOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\ClaimClaimableBalanceOperationResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/ClaimClaimableBalanceOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\ClawbackClaimableBalanceOperationResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/ClawbackClaimableBalanceOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\ClawbackClaimableBalanceOperationResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/ClawbackClaimableBalanceOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\ClawbackOperationResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/ClawbackOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\ClawbackOperationResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/ClawbackOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\CreateAccountOperationResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/CreateAccountOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\CreateAccountOperationResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/CreateAccountOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\CreateClaimableBalanceOperationResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/CreateClaimableBalanceOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\CreateClaimableBalanceOperationResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/CreateClaimableBalanceOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\CreatePassiveSellOfferResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/CreatePassiveSellOfferResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\CreatePassiveSellOfferResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/CreatePassiveSellOfferResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\EndSponsoringFutureReservesOperationResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/EndSponsoringFutureReservesOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\EndSponsoringFutureReservesOperationResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/EndSponsoringFutureReservesOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\ExtendFootprintTTLOperationResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/ExtendFootprintTTLOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\ExtendFootprintTTLOperationResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/ExtendFootprintTTLOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\InflationOperationResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/InflationOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\InvokeHostFunctionOperationResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/InvokeHostFunctionOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\InvokeHostFunctionOperationResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/InvokeHostFunctionOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\LiquidityPoolDepositOperationResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/LiquidityPoolDepositOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\LiquidityPoolDepositOperationResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/LiquidityPoolDepositOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\LiquidityPoolWithdrawOperationResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/LiquidityPoolWithdrawOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\LiquidityPoolWithdrawOperationResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/LiquidityPoolWithdrawOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\ManageBuyOfferOperationResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/ManageBuyOfferOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\ManageBuyOfferOperationResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/ManageBuyOfferOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\ManageDataOperationResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/ManageDataOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\ManageDataOperationResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/ManageDataOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\ManageSellOfferOperationResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/ManageSellOfferOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\ManageSellOfferOperationResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/ManageSellOfferOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\OperationLinksResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/OperationLinksResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\OperationLinksResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/OperationLinksResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\OperationResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/OperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\OperationResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/OperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\OperationsPageResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/OperationsPageResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\OperationsPageResponse\:\:getNextPage\(\) should return Soneso\\StellarSDK\\Responses\\Operations\\OperationsPageResponse\|null but returns Soneso\\StellarSDK\\Responses\\Response\|null\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/OperationsPageResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\OperationsPageResponse\:\:getPreviousPage\(\) should return Soneso\\StellarSDK\\Responses\\Operations\\OperationsPageResponse\|null but returns Soneso\\StellarSDK\\Responses\\Response\|null\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/OperationsPageResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\OperationsPageResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/OperationsPageResponse.php
+
+		-
+			message: '#^Call to an undefined method Iterator\<mixed, mixed\>\:\:append\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/OperationsResponse.php
+
+		-
+			message: '#^Call to an undefined method Iterator\<mixed, mixed\>\:\:count\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/OperationsResponse.php
+
+		-
+			message: '#^Class Soneso\\StellarSDK\\Responses\\Operations\\OperationsResponse extends generic class IteratorIterator but does not specify its types\: TKey, TValue, TIterator$#'
+			identifier: missingType.generics
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/OperationsResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\ParameterResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/ParameterResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\ParameterResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/ParameterResponse.php
+
+		-
+			message: '#^Call to an undefined method Iterator\<mixed, mixed\>\:\:append\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/ParametersResponse.php
+
+		-
+			message: '#^Call to an undefined method Iterator\<mixed, mixed\>\:\:count\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/ParametersResponse.php
+
+		-
+			message: '#^Class Soneso\\StellarSDK\\Responses\\Operations\\ParametersResponse extends generic class IteratorIterator but does not specify its types\: TKey, TValue, TIterator$#'
+			identifier: missingType.generics
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/ParametersResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\PathPaymentOperationResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/PathPaymentOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\PathPaymentOperationResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/PathPaymentOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\PathPaymentStrictReceiveOperationResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/PathPaymentStrictReceiveOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\PathPaymentStrictReceiveOperationResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/PathPaymentStrictReceiveOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\PathPaymentStrictSendOperationResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/PathPaymentStrictSendOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\PathPaymentStrictSendOperationResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/PathPaymentStrictSendOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\PaymentOperationResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/PaymentOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\PaymentOperationResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/PaymentOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\RestoreFootprintOperationResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/RestoreFootprintOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\RevokeSponsorshipOperationResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/RevokeSponsorshipOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\RevokeSponsorshipOperationResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/RevokeSponsorshipOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\SetOptionsOperationResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/SetOptionsOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\SetOptionsOperationResponse\:\:getClearFlags\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/SetOptionsOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\SetOptionsOperationResponse\:\:getClearFlagsS\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/SetOptionsOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\SetOptionsOperationResponse\:\:getSetFlags\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/SetOptionsOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\SetOptionsOperationResponse\:\:getSetFlagsS\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/SetOptionsOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\SetOptionsOperationResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/SetOptionsOperationResponse.php
+
+		-
+			message: '#^Property Soneso\\StellarSDK\\Responses\\Operations\\SetOptionsOperationResponse\:\:\$clearFlags type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/SetOptionsOperationResponse.php
+
+		-
+			message: '#^Property Soneso\\StellarSDK\\Responses\\Operations\\SetOptionsOperationResponse\:\:\$clearFlagsS type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/SetOptionsOperationResponse.php
+
+		-
+			message: '#^Property Soneso\\StellarSDK\\Responses\\Operations\\SetOptionsOperationResponse\:\:\$setFlags type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/SetOptionsOperationResponse.php
+
+		-
+			message: '#^Property Soneso\\StellarSDK\\Responses\\Operations\\SetOptionsOperationResponse\:\:\$setFlagsS type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/SetOptionsOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\SetTrustlineFlagsOperationResponse\:\:fromJson\(\) has parameter \$jsonData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/SetTrustlineFlagsOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\SetTrustlineFlagsOperationResponse\:\:getClearFlags\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/SetTrustlineFlagsOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\SetTrustlineFlagsOperationResponse\:\:getClearFlagsS\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/SetTrustlineFlagsOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\SetTrustlineFlagsOperationResponse\:\:getSetFlags\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/SetTrustlineFlagsOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\SetTrustlineFlagsOperationResponse\:\:getSetFlagsS\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/SetTrustlineFlagsOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Operations\\SetTrustlineFlagsOperationResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/SetTrustlineFlagsOperationResponse.php
+
+		-
+			message: '#^Property Soneso\\StellarSDK\\Responses\\Operations\\SetTrustlineFlagsOperationResponse\:\:\$clearFlags type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/SetTrustlineFlagsOperationResponse.php
+
+		-
+			message: '#^Property Soneso\\StellarSDK\\Responses\\Operations\\SetTrustlineFlagsOperationResponse\:\:\$clearFlagsS type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/SetTrustlineFlagsOperationResponse.php
+
+		-
+			message: '#^Property Soneso\\StellarSDK\\Responses\\Operations\\SetTrustlineFlagsOperationResponse\:\:\$setFlags type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/SetTrustlineFlagsOperationResponse.php
+
+		-
+			message: '#^Property Soneso\\StellarSDK\\Responses\\Operations\\SetTrustlineFlagsOperationResponse\:\:\$setFlagsS type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Operations/SetTrustlineFlagsOperationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\OrderBook\\OrderBookResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/OrderBook/OrderBookResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\OrderBook\\OrderBookResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/OrderBook/OrderBookResponse.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between Soneso\\StellarSDK\\Asset and null will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 2
+			path: Soneso/StellarSDK/Responses/OrderBook/OrderBookResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\OrderBook\\OrderBookRowResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/OrderBook/OrderBookRowResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\OrderBook\\OrderBookRowResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/OrderBook/OrderBookRowResponse.php
+
+		-
+			message: '#^Call to an undefined method Iterator\<mixed, mixed\>\:\:append\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Soneso/StellarSDK/Responses/OrderBook/OrderBookRowsResponse.php
+
+		-
+			message: '#^Call to an undefined method Iterator\<mixed, mixed\>\:\:count\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Soneso/StellarSDK/Responses/OrderBook/OrderBookRowsResponse.php
+
+		-
+			message: '#^Class Soneso\\StellarSDK\\Responses\\OrderBook\\OrderBookRowsResponse extends generic class IteratorIterator but does not specify its types\: TKey, TValue, TIterator$#'
+			identifier: missingType.generics
+			count: 1
+			path: Soneso/StellarSDK/Responses/OrderBook/OrderBookRowsResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Page\\PageResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Page/PageResponse.php
+
+		-
+			message: '#^Parameter \#3 \$e of static method Soneso\\StellarSDK\\Exceptions\\HorizonRequestException\:\:fromOtherException\(\) expects Exception, GuzzleHttp\\Exception\\GuzzleException given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Soneso/StellarSDK/Responses/Page/PageResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Page\\PagingLinksResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Page/PagingLinksResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Page\\PagingLinksResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Page/PagingLinksResponse.php
+
+		-
+			message: '#^Property Soneso\\StellarSDK\\Responses\\Page\\PagingLinksResponse\:\:\$next \(Soneso\\StellarSDK\\Responses\\Link\\LinkResponse\|null\) is never assigned null so it can be removed from the property type\.$#'
+			identifier: property.unusedType
+			count: 1
+			path: Soneso/StellarSDK/Responses/Page/PagingLinksResponse.php
+
+		-
+			message: '#^Property Soneso\\StellarSDK\\Responses\\Page\\PagingLinksResponse\:\:\$prev \(Soneso\\StellarSDK\\Responses\\Link\\LinkResponse\|null\) is never assigned null so it can be removed from the property type\.$#'
+			identifier: property.unusedType
+			count: 1
+			path: Soneso/StellarSDK/Responses/Page/PagingLinksResponse.php
+
+		-
+			message: '#^Call to an undefined method Iterator\<mixed, mixed\>\:\:append\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Soneso/StellarSDK/Responses/PaymentPath/PathAssetsResponse.php
+
+		-
+			message: '#^Call to an undefined method Iterator\<mixed, mixed\>\:\:count\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Soneso/StellarSDK/Responses/PaymentPath/PathAssetsResponse.php
+
+		-
+			message: '#^Class Soneso\\StellarSDK\\Responses\\PaymentPath\\PathAssetsResponse extends generic class IteratorIterator but does not specify its types\: TKey, TValue, TIterator$#'
+			identifier: missingType.generics
+			count: 1
+			path: Soneso/StellarSDK/Responses/PaymentPath/PathAssetsResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\PaymentPath\\PathLinksResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/PaymentPath/PathLinksResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\PaymentPath\\PathLinksResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/PaymentPath/PathLinksResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\PaymentPath\\PathResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/PaymentPath/PathResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\PaymentPath\\PathResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/PaymentPath/PathResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\PaymentPath\\PathsPageResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/PaymentPath/PathsPageResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\PaymentPath\\PathsPageResponse\:\:getNextPage\(\) should return Soneso\\StellarSDK\\Responses\\PaymentPath\\PathsPageResponse\|null but returns Soneso\\StellarSDK\\Responses\\Response\|null\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Responses/PaymentPath/PathsPageResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\PaymentPath\\PathsPageResponse\:\:getPreviousPage\(\) should return Soneso\\StellarSDK\\Responses\\PaymentPath\\PathsPageResponse\|null but returns Soneso\\StellarSDK\\Responses\\Response\|null\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Responses/PaymentPath/PathsPageResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\PaymentPath\\PathsPageResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/PaymentPath/PathsPageResponse.php
+
+		-
+			message: '#^Call to an undefined method Iterator\<mixed, mixed\>\:\:append\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Soneso/StellarSDK/Responses/PaymentPath/PathsResponse.php
+
+		-
+			message: '#^Call to an undefined method Iterator\<mixed, mixed\>\:\:count\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Soneso/StellarSDK/Responses/PaymentPath/PathsResponse.php
+
+		-
+			message: '#^Class Soneso\\StellarSDK\\Responses\\PaymentPath\\PathsResponse extends generic class IteratorIterator but does not specify its types\: TKey, TValue, TIterator$#'
+			identifier: missingType.generics
+			count: 1
+			path: Soneso/StellarSDK/Responses/PaymentPath/PathsResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Response\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Response.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Response\:\:setHeaders\(\) has parameter \$headers with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Response.php
+
+		-
+			message: '#^Using nullsafe method call on non\-nullable type Soneso\\StellarSDK\\Responses\\Account\\AccountDataValueResponse\|Soneso\\StellarSDK\\Responses\\Account\\AccountResponse\|Soneso\\StellarSDK\\Responses\\Account\\AccountsPageResponse\|Soneso\\StellarSDK\\Responses\\Asset\\AssetsPageResponse\|Soneso\\StellarSDK\\Responses\\ClaimableBalances\\ClaimableBalanceResponse\|Soneso\\StellarSDK\\Responses\\ClaimableBalances\\ClaimableBalancesPageResponse\|Soneso\\StellarSDK\\Responses\\Effects\\EffectsPageResponse\|Soneso\\StellarSDK\\Responses\\FeeStats\\FeeStatsResponse\|Soneso\\StellarSDK\\Responses\\Health\\HealthResponse\|Soneso\\StellarSDK\\Responses\\Ledger\\LedgerResponse\|Soneso\\StellarSDK\\Responses\\Ledger\\LedgersPageResponse\|Soneso\\StellarSDK\\Responses\\LiquidityPools\\LiquidityPoolResponse\|Soneso\\StellarSDK\\Responses\\LiquidityPools\\LiquidityPoolsPageResponse\|Soneso\\StellarSDK\\Responses\\Offers\\OfferResponse\|Soneso\\StellarSDK\\Responses\\Offers\\OffersPageResponse\|Soneso\\StellarSDK\\Responses\\Operations\\OperationResponse\|Soneso\\StellarSDK\\Responses\\Operations\\OperationsPageResponse\|Soneso\\StellarSDK\\Responses\\OrderBook\\OrderBookResponse\|Soneso\\StellarSDK\\Responses\\PaymentPath\\PathsPageResponse\|Soneso\\StellarSDK\\Responses\\Root\\RootResponse\|Soneso\\StellarSDK\\Responses\\TradeAggregations\\TradeAggregationsPageResponse\|Soneso\\StellarSDK\\Responses\\Trades\\TradeResponse\|Soneso\\StellarSDK\\Responses\\Trades\\TradesPageResponse\|Soneso\\StellarSDK\\Responses\\Transaction\\SubmitAsyncTransactionResponse\|Soneso\\StellarSDK\\Responses\\Transaction\\TransactionResponse\|Soneso\\StellarSDK\\Responses\\Transaction\\TransactionsPageResponse\|Soneso\\StellarSDK\\SEP\\Federation\\FederationResponse\|Soneso\\StellarSDK\\SEP\\Interactive\\SEP24FeeResponse\|Soneso\\StellarSDK\\SEP\\Interactive\\SEP24InfoResponse\|Soneso\\StellarSDK\\SEP\\Interactive\\SEP24InteractiveResponse\|Soneso\\StellarSDK\\SEP\\Interactive\\SEP24TransactionResponse\|Soneso\\StellarSDK\\SEP\\Interactive\\SEP24TransactionsResponse\|Soneso\\StellarSDK\\SEP\\KYCService\\CustomerFileResponse\|Soneso\\StellarSDK\\SEP\\KYCService\\GetCustomerFilesResponse\|Soneso\\StellarSDK\\SEP\\KYCService\\GetCustomerInfoResponse\|Soneso\\StellarSDK\\SEP\\KYCService\\PutCustomerInfoResponse\|Soneso\\StellarSDK\\SEP\\TransferServerService\\AnchorTransactionResponse\|Soneso\\StellarSDK\\SEP\\TransferServerService\\AnchorTransactionsResponse\|Soneso\\StellarSDK\\SEP\\TransferServerService\\DepositResponse\|Soneso\\StellarSDK\\SEP\\TransferServerService\\FeeResponse\|Soneso\\StellarSDK\\SEP\\TransferServerService\\InfoResponse\|Soneso\\StellarSDK\\SEP\\TransferServerService\\WithdrawResponse\|Soneso\\StellarSDK\\SEP\\WebAuth\\ChallengeResponse\|Soneso\\StellarSDK\\SEP\\WebAuthForContracts\\ContractChallengeResponse\. Use \-\> instead\.$#'
+			identifier: nullsafe.neverNull
+			count: 2
+			path: Soneso/StellarSDK/Responses/ResponseHandler.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Root\\RootResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Root/RootResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Root\\RootResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Root/RootResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\TradeAggregations\\TradeAggregationResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/TradeAggregations/TradeAggregationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\TradeAggregations\\TradeAggregationResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/TradeAggregations/TradeAggregationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\TradeAggregations\\TradeAggregationsPageResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/TradeAggregations/TradeAggregationsPageResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\TradeAggregations\\TradeAggregationsPageResponse\:\:getNextPage\(\) should return Soneso\\StellarSDK\\Responses\\TradeAggregations\\TradeAggregationsPageResponse\|null but returns Soneso\\StellarSDK\\Responses\\Response\|null\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Responses/TradeAggregations/TradeAggregationsPageResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\TradeAggregations\\TradeAggregationsPageResponse\:\:getPreviousPage\(\) should return Soneso\\StellarSDK\\Responses\\TradeAggregations\\TradeAggregationsPageResponse\|null but returns Soneso\\StellarSDK\\Responses\\Response\|null\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Responses/TradeAggregations/TradeAggregationsPageResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\TradeAggregations\\TradeAggregationsPageResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/TradeAggregations/TradeAggregationsPageResponse.php
+
+		-
+			message: '#^Call to an undefined method Iterator\<mixed, mixed\>\:\:append\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Soneso/StellarSDK/Responses/TradeAggregations/TradeAggregationsResponse.php
+
+		-
+			message: '#^Call to an undefined method Iterator\<mixed, mixed\>\:\:count\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Soneso/StellarSDK/Responses/TradeAggregations/TradeAggregationsResponse.php
+
+		-
+			message: '#^Class Soneso\\StellarSDK\\Responses\\TradeAggregations\\TradeAggregationsResponse extends generic class IteratorIterator but does not specify its types\: TKey, TValue, TIterator$#'
+			identifier: missingType.generics
+			count: 1
+			path: Soneso/StellarSDK/Responses/TradeAggregations/TradeAggregationsResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Trades\\TradeLinksResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Trades/TradeLinksResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Trades\\TradeLinksResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Trades/TradeLinksResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Trades\\TradePriceResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Trades/TradePriceResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Trades\\TradePriceResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Trades/TradePriceResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Trades\\TradeResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Trades/TradeResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Trades\\TradeResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Trades/TradeResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Trades\\TradesPageResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Trades/TradesPageResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Trades\\TradesPageResponse\:\:getNextPage\(\) should return Soneso\\StellarSDK\\Responses\\Trades\\TradesPageResponse\|null but returns Soneso\\StellarSDK\\Responses\\Response\|null\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Responses/Trades/TradesPageResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Trades\\TradesPageResponse\:\:getPreviousPage\(\) should return Soneso\\StellarSDK\\Responses\\Trades\\TradesPageResponse\|null but returns Soneso\\StellarSDK\\Responses\\Response\|null\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Responses/Trades/TradesPageResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Trades\\TradesPageResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Trades/TradesPageResponse.php
+
+		-
+			message: '#^Call to an undefined method Iterator\<mixed, mixed\>\:\:append\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Soneso/StellarSDK/Responses/Trades/TradesResponse.php
+
+		-
+			message: '#^Call to an undefined method Iterator\<mixed, mixed\>\:\:count\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Soneso/StellarSDK/Responses/Trades/TradesResponse.php
+
+		-
+			message: '#^Class Soneso\\StellarSDK\\Responses\\Trades\\TradesResponse extends generic class IteratorIterator but does not specify its types\: TKey, TValue, TIterator$#'
+			identifier: missingType.generics
+			count: 1
+			path: Soneso/StellarSDK/Responses/Trades/TradesResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Transaction\\ExtrasResultCodes\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Transaction/ExtrasResultCodes.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Transaction\\ExtrasResultCodes\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Transaction/ExtrasResultCodes.php
+
+		-
+			message: '#^Property Soneso\\StellarSDK\\Responses\\Transaction\\ExtrasResultCodes\:\:\$operationsResultCodes type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Transaction/ExtrasResultCodes.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Transaction\\FeeBumpTransactionResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Transaction/FeeBumpTransactionResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Transaction\\FeeBumpTransactionResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Transaction/FeeBumpTransactionResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Transaction\\InnerTransactionResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Transaction/InnerTransactionResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Transaction\\InnerTransactionResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Transaction/InnerTransactionResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Transaction\\PreconditionsLedgerBoundsResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Transaction/PreconditionsLedgerBoundsResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Transaction\\PreconditionsLedgerBoundsResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Transaction/PreconditionsLedgerBoundsResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Transaction\\PreconditionsTimeBoundsResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Transaction/PreconditionsTimeBoundsResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Transaction\\PreconditionsTimeBoundsResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Transaction/PreconditionsTimeBoundsResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Transaction\\SubmitAsyncTransactionResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Transaction/SubmitAsyncTransactionResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Transaction\\SubmitTransactionResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Transaction/SubmitTransactionResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Transaction\\SubmitTransactionResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Transaction/SubmitTransactionResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Transaction\\SubmitTransactionResponseExtras\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Transaction/SubmitTransactionResponseExtras.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Transaction\\SubmitTransactionResponseExtras\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Transaction/SubmitTransactionResponseExtras.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Transaction\\TransactionLinksResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Transaction/TransactionLinksResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Transaction\\TransactionLinksResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Transaction/TransactionLinksResponse.php
+
+		-
+			message: '#^Property Soneso\\StellarSDK\\Responses\\Transaction\\TransactionLinksResponse\:\:\$account is never read, only written\.$#'
+			identifier: property.onlyWritten
+			count: 1
+			path: Soneso/StellarSDK/Responses/Transaction/TransactionLinksResponse.php
+
+		-
+			message: '#^Property Soneso\\StellarSDK\\Responses\\Transaction\\TransactionLinksResponse\:\:\$effects is never read, only written\.$#'
+			identifier: property.onlyWritten
+			count: 1
+			path: Soneso/StellarSDK/Responses/Transaction/TransactionLinksResponse.php
+
+		-
+			message: '#^Property Soneso\\StellarSDK\\Responses\\Transaction\\TransactionLinksResponse\:\:\$ledger is unused\.$#'
+			identifier: property.unused
+			count: 1
+			path: Soneso/StellarSDK/Responses/Transaction/TransactionLinksResponse.php
+
+		-
+			message: '#^Property Soneso\\StellarSDK\\Responses\\Transaction\\TransactionLinksResponse\:\:\$operations is never read, only written\.$#'
+			identifier: property.onlyWritten
+			count: 1
+			path: Soneso/StellarSDK/Responses/Transaction/TransactionLinksResponse.php
+
+		-
+			message: '#^Property Soneso\\StellarSDK\\Responses\\Transaction\\TransactionLinksResponse\:\:\$precedes is never read, only written\.$#'
+			identifier: property.onlyWritten
+			count: 1
+			path: Soneso/StellarSDK/Responses/Transaction/TransactionLinksResponse.php
+
+		-
+			message: '#^Property Soneso\\StellarSDK\\Responses\\Transaction\\TransactionLinksResponse\:\:\$self is never read, only written\.$#'
+			identifier: property.onlyWritten
+			count: 1
+			path: Soneso/StellarSDK/Responses/Transaction/TransactionLinksResponse.php
+
+		-
+			message: '#^Property Soneso\\StellarSDK\\Responses\\Transaction\\TransactionLinksResponse\:\:\$succeeds is never read, only written\.$#'
+			identifier: property.onlyWritten
+			count: 1
+			path: Soneso/StellarSDK/Responses/Transaction/TransactionLinksResponse.php
+
+		-
+			message: '#^Property Soneso\\StellarSDK\\Responses\\Transaction\\TransactionLinksResponse\:\:\$transaction is never read, only written\.$#'
+			identifier: property.onlyWritten
+			count: 1
+			path: Soneso/StellarSDK/Responses/Transaction/TransactionLinksResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Transaction\\TransactionPreconditionsResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Transaction/TransactionPreconditionsResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Transaction\\TransactionPreconditionsResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Transaction/TransactionPreconditionsResponse.php
+
+		-
+			message: '#^Property Soneso\\StellarSDK\\Responses\\Transaction\\TransactionPreconditionsResponse\:\:\$extraSigners type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Transaction/TransactionPreconditionsResponse.php
+
+		-
+			message: '#^Match expression does not handle remaining value\: mixed$#'
+			identifier: match.unhandled
+			count: 1
+			path: Soneso/StellarSDK/Responses/Transaction/TransactionResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Transaction\\TransactionResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Transaction/TransactionResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Transaction\\TransactionResponse\:\:getFeeMetaXdr\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Transaction/TransactionResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Transaction\\TransactionResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Transaction/TransactionResponse.php
+
+		-
+			message: '#^Property Soneso\\StellarSDK\\Responses\\Transaction\\TransactionResponse\:\:\$feeMetaXdr type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Transaction/TransactionResponse.php
+
+		-
+			message: '#^Property Soneso\\StellarSDK\\Responses\\Transaction\\TransactionResponse\:\:\$preconditions \(Soneso\\StellarSDK\\Responses\\Transaction\\TransactionPreconditionsResponse\|null\) is never assigned null so it can be removed from the property type\.$#'
+			identifier: property.unusedType
+			count: 1
+			path: Soneso/StellarSDK/Responses/Transaction/TransactionResponse.php
+
+		-
+			message: '#^Call to an undefined method Iterator\<mixed, mixed\>\:\:append\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Soneso/StellarSDK/Responses/Transaction/TransactionSignaturesResponse.php
+
+		-
+			message: '#^Call to an undefined method Iterator\<mixed, mixed\>\:\:count\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Soneso/StellarSDK/Responses/Transaction/TransactionSignaturesResponse.php
+
+		-
+			message: '#^Class Soneso\\StellarSDK\\Responses\\Transaction\\TransactionSignaturesResponse extends generic class IteratorIterator but does not specify its types\: TKey, TValue, TIterator$#'
+			identifier: missingType.generics
+			count: 1
+			path: Soneso/StellarSDK/Responses/Transaction/TransactionSignaturesResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Transaction\\TransactionsPageResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Transaction/TransactionsPageResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Transaction\\TransactionsPageResponse\:\:getNextPage\(\) should return Soneso\\StellarSDK\\Responses\\Transaction\\TransactionsPageResponse\|null but returns Soneso\\StellarSDK\\Responses\\Response\|null\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Responses/Transaction/TransactionsPageResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Transaction\\TransactionsPageResponse\:\:getPreviousPage\(\) should return Soneso\\StellarSDK\\Responses\\Transaction\\TransactionsPageResponse\|null but returns Soneso\\StellarSDK\\Responses\\Response\|null\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Responses/Transaction/TransactionsPageResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Responses\\Transaction\\TransactionsPageResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Responses/Transaction/TransactionsPageResponse.php
+
+		-
+			message: '#^Call to an undefined method Iterator\<mixed, mixed\>\:\:append\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Soneso/StellarSDK/Responses/Transaction/TransactionsResponse.php
+
+		-
+			message: '#^Call to an undefined method Iterator\<mixed, mixed\>\:\:count\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Soneso/StellarSDK/Responses/Transaction/TransactionsResponse.php
+
+		-
+			message: '#^Class Soneso\\StellarSDK\\Responses\\Transaction\\TransactionsResponse extends generic class IteratorIterator but does not specify its types\: TKey, TValue, TIterator$#'
+			identifier: missingType.generics
+			count: 1
+			path: Soneso/StellarSDK/Responses/Transaction/TransactionsResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\SEP\\CrossBorderPayments\\CrossBorderPaymentsService\:\:buildHeaders\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/SEP/CrossBorderPayments/CrossBorderPaymentsService.php
+
+		-
+			message: '#^Constructor of class Soneso\\StellarSDK\\SEP\\CrossBorderPayments\\SEP31PostTransactionsRequest has an unused parameter \$fields\.$#'
+			identifier: constructor.unusedParameter
+			count: 1
+			path: Soneso/StellarSDK/SEP/CrossBorderPayments/SEP31PostTransactionsRequest.php
+
+		-
+			message: '#^Constructor of class Soneso\\StellarSDK\\SEP\\CrossBorderPayments\\SEP31ReceiveAssetInfo has an unused parameter \$fields\.$#'
+			identifier: constructor.unusedParameter
+			count: 1
+			path: Soneso/StellarSDK/SEP/CrossBorderPayments/SEP31ReceiveAssetInfo.php
+
+		-
+			message: '#^Constructor of class Soneso\\StellarSDK\\SEP\\CrossBorderPayments\\SEP31ReceiveAssetInfo has an unused parameter \$receiverSep12Type\.$#'
+			identifier: constructor.unusedParameter
+			count: 1
+			path: Soneso/StellarSDK/SEP/CrossBorderPayments/SEP31ReceiveAssetInfo.php
+
+		-
+			message: '#^Constructor of class Soneso\\StellarSDK\\SEP\\CrossBorderPayments\\SEP31ReceiveAssetInfo has an unused parameter \$senderSep12Type\.$#'
+			identifier: constructor.unusedParameter
+			count: 1
+			path: Soneso/StellarSDK/SEP/CrossBorderPayments/SEP31ReceiveAssetInfo.php
+
+		-
+			message: '#^Call to an undefined static method Soneso\\StellarSDK\\SEP\\Derivation\\WordList\:\:English\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 3
+			path: Soneso/StellarSDK/SEP/Derivation/BIP39.php
+
+		-
+			message: '#^Call to function is_array\(\) with array\<string\> will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: Soneso/StellarSDK/SEP/Derivation/BIP39.php
+
+		-
+			message: '#^Property Soneso\\StellarSDK\\SEP\\Derivation\\BIP39\:\:\$rawBinaryChunks type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/SEP/Derivation/BIP39.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\SEP\\Derivation\\HDNode\:\:parseDerivationPath\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/SEP/Derivation/HDNode.php
+
+		-
+			message: '#^Class Soneso\\StellarSDK\\SEP\\Derivation\\WordList referenced with incorrect case\: Soneso\\StellarSDK\\SEP\\Derivation\\Wordlist\.$#'
+			identifier: class.nameCase
+			count: 1
+			path: Soneso/StellarSDK/SEP/Derivation/Mnemonic.php
+
+		-
+			message: '#^Property Soneso\\StellarSDK\\SEP\\Derivation\\Mnemonic\:\:\$rawBinaryChunks type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/SEP/Derivation/Mnemonic.php
+
+		-
+			message: '#^Property Soneso\\StellarSDK\\SEP\\Derivation\\Mnemonic\:\:\$words type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/SEP/Derivation/Mnemonic.php
+
+		-
+			message: '#^Property Soneso\\StellarSDK\\SEP\\Derivation\\Mnemonic\:\:\$wordsIndex type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/SEP/Derivation/Mnemonic.php
+
+		-
+			message: '#^Property Soneso\\StellarSDK\\SEP\\Derivation\\WordList\:\:\$instances type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/SEP/Derivation/WordList.php
+
+		-
+			message: '#^Property Soneso\\StellarSDK\\SEP\\Derivation\\WordList\:\:\$words type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/SEP/Derivation/WordList.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\SEP\\Federation\\FederationResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/SEP/Federation/FederationResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\SEP\\Interactive\\InteractiveService\:\:handleErrorResponse\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: Soneso/StellarSDK/SEP/Interactive/InteractiveService.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\SEP\\Interactive\\InteractiveService\:\:handleForbiddenResponse\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: Soneso/StellarSDK/SEP/Interactive/InteractiveService.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\SEP\\Interactive\\InteractiveService\:\:setMockHandlerStack\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: Soneso/StellarSDK/SEP/Interactive/InteractiveService.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\SEP\\KYCService\\CustomerFileResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/SEP/KYCService/CustomerFileResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\SEP\\KYCService\\CustomerFileResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/SEP/KYCService/CustomerFileResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\SEP\\KYCService\\GetCustomerFilesRequestBuilder\:\:request\(\) should return Soneso\\StellarSDK\\SEP\\KYCService\\GetCustomerFilesResponse but returns Soneso\\StellarSDK\\Responses\\Response\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/SEP/KYCService/GetCustomerFilesRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\SEP\\KYCService\\GetCustomerFilesResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/SEP/KYCService/GetCustomerFilesResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\SEP\\KYCService\\GetCustomerFilesResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/SEP/KYCService/GetCustomerFilesResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\SEP\\KYCService\\GetCustomerInfoField\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/SEP/KYCService/GetCustomerInfoField.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\SEP\\KYCService\\GetCustomerInfoField\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/SEP/KYCService/GetCustomerInfoField.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\SEP\\KYCService\\GetCustomerInfoProvidedField\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/SEP/KYCService/GetCustomerInfoProvidedField.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\SEP\\KYCService\\GetCustomerInfoProvidedField\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/SEP/KYCService/GetCustomerInfoProvidedField.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\SEP\\KYCService\\GetCustomerInfoRequestBuilder\:\:request\(\) should return Soneso\\StellarSDK\\SEP\\KYCService\\GetCustomerInfoResponse but returns Soneso\\StellarSDK\\Responses\\Response\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/SEP/KYCService/GetCustomerInfoRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\SEP\\KYCService\\GetCustomerInfoResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/SEP/KYCService/GetCustomerInfoResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\SEP\\KYCService\\GetCustomerInfoResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/SEP/KYCService/GetCustomerInfoResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\SEP\\KYCService\\KYCService\:\:setMockHandlerStack\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: Soneso/StellarSDK/SEP/KYCService/KYCService.php
+
+		-
+			message: '#^Using nullsafe property access on non\-nullable type Soneso\\StellarSDK\\SEP\\StandardKYCFields\\StandardKYCFields\. Use \-\> instead\.$#'
+			identifier: nullsafe.neverNull
+			count: 4
+			path: Soneso/StellarSDK/SEP/KYCService/KYCService.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\SEP\\KYCService\\PostCustomerFileRequestBuilder\:\:request\(\) should return Soneso\\StellarSDK\\SEP\\KYCService\\CustomerFileResponse but returns Soneso\\StellarSDK\\Responses\\Response\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/SEP/KYCService/PostCustomerFileRequestBuilder.php
+
+		-
+			message: '#^Property Soneso\\StellarSDK\\SEP\\KYCService\\PutCustomerInfoRequest\:\:\$customFields type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/SEP/KYCService/PutCustomerInfoRequest.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\SEP\\KYCService\\PutCustomerInfoRequestBuilder\:\:request\(\) should return Soneso\\StellarSDK\\SEP\\KYCService\\PutCustomerInfoResponse but returns Soneso\\StellarSDK\\Responses\\Response\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/SEP/KYCService/PutCustomerInfoRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\SEP\\KYCService\\PutCustomerInfoResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/SEP/KYCService/PutCustomerInfoResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\SEP\\KYCService\\PutCustomerInfoResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/SEP/KYCService/PutCustomerInfoResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\SEP\\KYCService\\PutCustomerVerificationRequestBuilder\:\:request\(\) should return Soneso\\StellarSDK\\SEP\\KYCService\\GetCustomerInfoResponse but returns Soneso\\StellarSDK\\Responses\\Response\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/SEP/KYCService/PutCustomerVerificationRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\SEP\\Quote\\QuoteService\:\:buildHeaders\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/SEP/Quote/QuoteService.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between string and null will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 1
+			path: Soneso/StellarSDK/SEP/Quote/QuoteService.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\SEP\\Recovery\\RecoveryService\:\:buildHeaders\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/SEP/Recovery/RecoveryService.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\SEP\\Recovery\\SEP30AuthMethod\:\:toJson\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/SEP/Recovery/SEP30AuthMethod.php
+
+		-
+			message: '#^Instanceof between Soneso\\StellarSDK\\SEP\\Recovery\\SEP30RequestIdentity and Soneso\\StellarSDK\\SEP\\Recovery\\SEP30RequestIdentity will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
+			count: 1
+			path: Soneso/StellarSDK/SEP/Recovery/SEP30Request.php
+
+		-
+			message: '#^Instanceof between Soneso\\StellarSDK\\SEP\\Recovery\\SEP30AuthMethod and Soneso\\StellarSDK\\SEP\\Recovery\\SEP30AuthMethod will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
+			count: 1
+			path: Soneso/StellarSDK/SEP/Recovery/SEP30RequestIdentity.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\SEP\\Recovery\\SEP30RequestIdentity\:\:toJson\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/SEP/Recovery/SEP30RequestIdentity.php
+
+		-
+			message: '#^Call to an undefined method Iterator\<mixed, mixed\>\:\:append\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Soneso/StellarSDK/SEP/Toml/Currencies.php
+
+		-
+			message: '#^Call to an undefined method Iterator\<mixed, mixed\>\:\:count\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Soneso/StellarSDK/SEP/Toml/Currencies.php
+
+		-
+			message: '#^Class Soneso\\StellarSDK\\SEP\\Toml\\Currencies extends generic class IteratorIterator but does not specify its types\: TKey, TValue, TIterator$#'
+			identifier: missingType.generics
+			count: 1
+			path: Soneso/StellarSDK/SEP/Toml/Currencies.php
+
+		-
+			message: '#^Property Soneso\\StellarSDK\\SEP\\Toml\\Currency\:\:\$collateralAddressMessages type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/SEP/Toml/Currency.php
+
+		-
+			message: '#^Property Soneso\\StellarSDK\\SEP\\Toml\\Currency\:\:\$collateralAddressSignatures type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/SEP/Toml/Currency.php
+
+		-
+			message: '#^Property Soneso\\StellarSDK\\SEP\\Toml\\Currency\:\:\$collateralAddresses type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/SEP/Toml/Currency.php
+
+		-
+			message: '#^Property Soneso\\StellarSDK\\SEP\\Toml\\GeneralInformation\:\:\$accounts type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/SEP/Toml/GeneralInformation.php
+
+		-
+			message: '#^Call to an undefined method Iterator\<mixed, mixed\>\:\:append\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Soneso/StellarSDK/SEP/Toml/Principals.php
+
+		-
+			message: '#^Call to an undefined method Iterator\<mixed, mixed\>\:\:count\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Soneso/StellarSDK/SEP/Toml/Principals.php
+
+		-
+			message: '#^Class Soneso\\StellarSDK\\SEP\\Toml\\Principals extends generic class IteratorIterator but does not specify its types\: TKey, TValue, TIterator$#'
+			identifier: missingType.generics
+			count: 1
+			path: Soneso/StellarSDK/SEP/Toml/Principals.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\SEP\\Toml\\StellarToml\:\:currencyFromItem\(\) has parameter \$item with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/SEP/Toml/StellarToml.php
+
+		-
+			message: '#^Call to an undefined method Iterator\<mixed, mixed\>\:\:append\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Soneso/StellarSDK/SEP/Toml/Validators.php
+
+		-
+			message: '#^Call to an undefined method Iterator\<mixed, mixed\>\:\:count\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Soneso/StellarSDK/SEP/Toml/Validators.php
+
+		-
+			message: '#^Class Soneso\\StellarSDK\\SEP\\Toml\\Validators extends generic class IteratorIterator but does not specify its types\: TKey, TValue, TIterator$#'
+			identifier: missingType.generics
+			count: 1
+			path: Soneso/StellarSDK/SEP/Toml/Validators.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\SEP\\TransferServerService\\InfoResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/SEP/TransferServerService/InfoResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\SEP\\TransferServerService\\InfoResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/SEP/TransferServerService/InfoResponse.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between string and null will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 1
+			path: Soneso/StellarSDK/SEP/TransferServerService/TransferServerService.php
+
+		-
+			message: '#^Parameter &\$lines by\-ref type of method Soneso\\StellarSDK\\SEP\\TxRep\\TxRep\:\:transactionToLines\(\) expects array\<string, string\>, array given\.$#'
+			identifier: parameterByRef.type
+			count: 7
+			path: Soneso/StellarSDK/SEP/TxRep/TxRep.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\SEP\\URIScheme\\URIScheme\:\:setMockHandlerStack\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: Soneso/StellarSDK/SEP/URIScheme/URIScheme.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\SEP\\WebAuth\\ChallengeRequestBuilder\:\:forQueryParameters\(\) has parameter \$queryParameters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/SEP/WebAuth/ChallengeRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\SEP\\WebAuth\\ChallengeRequestBuilder\:\:request\(\) should return Soneso\\StellarSDK\\SEP\\WebAuth\\ChallengeResponse but returns Soneso\\StellarSDK\\Responses\\Response\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/SEP/WebAuth/ChallengeRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\SEP\\WebAuth\\ChallengeResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/SEP/WebAuth/ChallengeResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\SEP\\WebAuth\\ChallengeResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/SEP/WebAuth/ChallengeResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\SEP\\WebAuth\\SubmitCompletedChallengeResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/SEP/WebAuth/SubmitCompletedChallengeResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\SEP\\WebAuth\\SubmitCompletedChallengeResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/SEP/WebAuth/SubmitCompletedChallengeResponse.php
+
+		-
+			message: '#^Instanceof between Soneso\\StellarSDK\\Crypto\\KeyPair and Soneso\\StellarSDK\\Crypto\\KeyPair will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
+			count: 1
+			path: Soneso/StellarSDK/SEP/WebAuth/WebAuth.php
+
+		-
+			message: '#^Instanceof between Soneso\\StellarSDK\\Xdr\\XdrOperation and Soneso\\StellarSDK\\Xdr\\XdrOperation will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
+			count: 1
+			path: Soneso/StellarSDK/SEP/WebAuth/WebAuth.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\SEP\\WebAuth\\WebAuth\:\:validateChallenge\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: Soneso/StellarSDK/SEP/WebAuth/WebAuth.php
+
+		-
+			message: '#^Using nullsafe method call on non\-nullable type Soneso\\StellarSDK\\Crypto\\KeyPair\. Use \-\> instead\.$#'
+			identifier: nullsafe.neverNull
+			count: 1
+			path: Soneso/StellarSDK/SEP/WebAuth/WebAuth.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\SEP\\WebAuthForContracts\\ContractChallengeRequestBuilder\:\:forQueryParameters\(\) has parameter \$queryParameters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/SEP/WebAuthForContracts/ContractChallengeRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\SEP\\WebAuthForContracts\\ContractChallengeRequestBuilder\:\:request\(\) should return Soneso\\StellarSDK\\SEP\\WebAuthForContracts\\ContractChallengeResponse but returns Soneso\\StellarSDK\\Responses\\Response\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/SEP/WebAuthForContracts/ContractChallengeRequestBuilder.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\SEP\\WebAuthForContracts\\ContractChallengeResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/SEP/WebAuthForContracts/ContractChallengeResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\SEP\\WebAuthForContracts\\ContractChallengeResponse\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/SEP/WebAuthForContracts/ContractChallengeResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\SEP\\WebAuthForContracts\\SubmitContractChallengeResponse\:\:fromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/SEP/WebAuthForContracts/SubmitContractChallengeResponse.php
+
+		-
+			message: '#^Instanceof between Soneso\\StellarSDK\\Crypto\\KeyPair and Soneso\\StellarSDK\\Crypto\\KeyPair will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
+			count: 1
+			path: Soneso/StellarSDK/SEP/WebAuthForContracts/WebAuthForContracts.php
+
+		-
+			message: '#^Instanceof between Soneso\\StellarSDK\\Soroban\\SorobanAuthorizationEntry and Soneso\\StellarSDK\\Soroban\\SorobanAuthorizationEntry will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
+			count: 1
+			path: Soneso/StellarSDK/SEP/WebAuthForContracts/WebAuthForContracts.php
+
+		-
+			message: '#^PHPDoc tag @var with type Soneso\\StellarSDK\\Xdr\\XdrSCSpecUDTUnionCaseV0 is not subtype of native type null\.$#'
+			identifier: varTag.nativeType
+			count: 1
+			path: Soneso/StellarSDK/Soroban/Contract/ContractSpec.php
+
+		-
+			message: '#^Variable \$scVals in PHPDoc tag @var does not match assigned variable \$scValues\.$#'
+			identifier: varTag.differentVariable
+			count: 2
+			path: Soneso/StellarSDK/Soroban/Contract/ContractSpec.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Soroban\\Contract\\NativeUnionVal\:\:__construct\(\) has parameter \$values with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Soroban/Contract/NativeUnionVal.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Soroban\\Contract\\SorobanClient\:\:buildInvokeMethodTx\(\) has parameter \$args with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Soroban/Contract/SorobanClient.php
+
+		-
+			message: '#^Call to an undefined method Iterator\<int, Soneso\\StellarSDK\\Soroban\\Requests\\EventFilter\>\:\:append\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Soneso/StellarSDK/Soroban/Requests/EventFilters.php
+
+		-
+			message: '#^Call to an undefined method Iterator\<int, Soneso\\StellarSDK\\Soroban\\Requests\\EventFilter\>\:\:count\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Soneso/StellarSDK/Soroban/Requests/EventFilters.php
+
+		-
+			message: '#^Parameter \#1 \$iterator of method IteratorIterator\<int,Soneso\\StellarSDK\\Soroban\\Requests\\EventFilter,ArrayIterator\<int, Soneso\\StellarSDK\\Soroban\\Requests\\EventFilter\>\>\:\:__construct\(\) expects ArrayIterator\<int, Soneso\\StellarSDK\\Soroban\\Requests\\EventFilter\>, ArrayIterator\<int\|string, Soneso\\StellarSDK\\Soroban\\Requests\\EventFilter\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Soneso/StellarSDK/Soroban/Requests/EventFilters.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Soroban\\Requests\\PaginationOptions\:\:getRequestParams\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Soroban/Requests/PaginationOptions.php
+
+		-
+			message: '#^Call to an undefined method Iterator\<int, Soneso\\StellarSDK\\Soroban\\Requests\\TopicFilter\>\:\:append\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Soneso/StellarSDK/Soroban/Requests/TopicFilters.php
+
+		-
+			message: '#^Call to an undefined method Iterator\<int, Soneso\\StellarSDK\\Soroban\\Requests\\TopicFilter\>\:\:count\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Soneso/StellarSDK/Soroban/Requests/TopicFilters.php
+
+		-
+			message: '#^Parameter \#1 \$iterator of method IteratorIterator\<int,Soneso\\StellarSDK\\Soroban\\Requests\\TopicFilter,ArrayIterator\<int, Soneso\\StellarSDK\\Soroban\\Requests\\TopicFilter\>\>\:\:__construct\(\) expects ArrayIterator\<int, Soneso\\StellarSDK\\Soroban\\Requests\\TopicFilter\>, ArrayIterator\<int\|string, Soneso\\StellarSDK\\Soroban\\Requests\\TopicFilter\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Soneso/StellarSDK/Soroban/Requests/TopicFilters.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Soroban\\Responses\\EventInfo\:\:fromJson\(\) should return static\(Soneso\\StellarSDK\\Soroban\\Responses\\EventInfo\) but returns Soneso\\StellarSDK\\Soroban\\Responses\\EventInfo\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Soroban/Responses/EventInfo.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Soroban\\Responses\\GetEventsResponse\:\:fromJson\(\) should return static\(Soneso\\StellarSDK\\Soroban\\Responses\\GetEventsResponse\) but returns Soneso\\StellarSDK\\Soroban\\Responses\\GetEventsResponse\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Soroban/Responses/GetEventsResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Soroban\\Responses\\GetFeeStatsResponse\:\:fromJson\(\) should return static\(Soneso\\StellarSDK\\Soroban\\Responses\\GetFeeStatsResponse\) but returns Soneso\\StellarSDK\\Soroban\\Responses\\GetFeeStatsResponse\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Soroban/Responses/GetFeeStatsResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Soroban\\Responses\\GetHealthResponse\:\:fromJson\(\) should return static\(Soneso\\StellarSDK\\Soroban\\Responses\\GetHealthResponse\) but returns Soneso\\StellarSDK\\Soroban\\Responses\\GetHealthResponse\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Soroban/Responses/GetHealthResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Soroban\\Responses\\GetLatestLedgerResponse\:\:fromJson\(\) should return static\(Soneso\\StellarSDK\\Soroban\\Responses\\GetLatestLedgerResponse\) but returns Soneso\\StellarSDK\\Soroban\\Responses\\GetLatestLedgerResponse\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Soroban/Responses/GetLatestLedgerResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Soroban\\Responses\\GetLedgerEntriesResponse\:\:fromJson\(\) should return static\(Soneso\\StellarSDK\\Soroban\\Responses\\GetLedgerEntriesResponse\) but returns Soneso\\StellarSDK\\Soroban\\Responses\\GetLedgerEntriesResponse\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Soroban/Responses/GetLedgerEntriesResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Soroban\\Responses\\GetLedgersResponse\:\:fromJson\(\) should return static\(Soneso\\StellarSDK\\Soroban\\Responses\\GetLedgersResponse\) but returns Soneso\\StellarSDK\\Soroban\\Responses\\GetLedgersResponse\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Soroban/Responses/GetLedgersResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Soroban\\Responses\\GetNetworkResponse\:\:fromJson\(\) should return static\(Soneso\\StellarSDK\\Soroban\\Responses\\GetNetworkResponse\) but returns Soneso\\StellarSDK\\Soroban\\Responses\\GetNetworkResponse\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Soroban/Responses/GetNetworkResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Soroban\\Responses\\GetTransactionResponse\:\:fromJson\(\) should return static\(Soneso\\StellarSDK\\Soroban\\Responses\\GetTransactionResponse\) but returns Soneso\\StellarSDK\\Soroban\\Responses\\GetTransactionResponse\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Soroban/Responses/GetTransactionResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Soroban\\Responses\\GetTransactionsResponse\:\:fromJson\(\) should return static\(Soneso\\StellarSDK\\Soroban\\Responses\\GetTransactionsResponse\) but returns Soneso\\StellarSDK\\Soroban\\Responses\\GetTransactionsResponse\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Soroban/Responses/GetTransactionsResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Soroban\\Responses\\GetVersionInfoResponse\:\:fromJson\(\) should return static\(Soneso\\StellarSDK\\Soroban\\Responses\\GetVersionInfoResponse\) but returns Soneso\\StellarSDK\\Soroban\\Responses\\GetVersionInfoResponse\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Soroban/Responses/GetVersionInfoResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Soroban\\Responses\\InclusionFee\:\:fromJson\(\) should return static\(Soneso\\StellarSDK\\Soroban\\Responses\\InclusionFee\) but returns Soneso\\StellarSDK\\Soroban\\Responses\\InclusionFee\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Soroban/Responses/InclusionFee.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Soroban\\Responses\\LedgerEntry\:\:fromJson\(\) should return static\(Soneso\\StellarSDK\\Soroban\\Responses\\LedgerEntry\) but returns Soneso\\StellarSDK\\Soroban\\Responses\\LedgerEntry\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Soroban/Responses/LedgerEntry.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Soroban\\Responses\\LedgerEntryChange\:\:fromJson\(\) should return static\(Soneso\\StellarSDK\\Soroban\\Responses\\LedgerEntryChange\) but returns Soneso\\StellarSDK\\Soroban\\Responses\\LedgerEntryChange\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Soroban/Responses/LedgerEntryChange.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Soroban\\Responses\\LedgerInfo\:\:fromJson\(\) should return static\(Soneso\\StellarSDK\\Soroban\\Responses\\LedgerInfo\) but returns Soneso\\StellarSDK\\Soroban\\Responses\\LedgerInfo\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Soroban/Responses/LedgerInfo.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Soroban\\Responses\\RestorePreamble\:\:fromJson\(\) should return static\(Soneso\\StellarSDK\\Soroban\\Responses\\RestorePreamble\) but returns Soneso\\StellarSDK\\Soroban\\Responses\\RestorePreamble\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Soroban/Responses/RestorePreamble.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Soroban\\Responses\\SendTransactionResponse\:\:fromJson\(\) should return static\(Soneso\\StellarSDK\\Soroban\\Responses\\SendTransactionResponse\) but returns Soneso\\StellarSDK\\Soroban\\Responses\\SendTransactionResponse\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Soroban/Responses/SendTransactionResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Soroban\\Responses\\SimulateTransactionResponse\:\:fromJson\(\) should return static\(Soneso\\StellarSDK\\Soroban\\Responses\\SimulateTransactionResponse\) but returns Soneso\\StellarSDK\\Soroban\\Responses\\SimulateTransactionResponse\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Soroban/Responses/SimulateTransactionResponse.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between array\<string\> and null will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 1
+			path: Soneso/StellarSDK/Soroban/Responses/SimulateTransactionResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Soroban\\Responses\\SimulateTransactionResult\:\:fromJson\(\) should return static\(Soneso\\StellarSDK\\Soroban\\Responses\\SimulateTransactionResult\) but returns Soneso\\StellarSDK\\Soroban\\Responses\\SimulateTransactionResult\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Soroban/Responses/SimulateTransactionResult.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Soroban\\Responses\\SimulateTransactionResult\:\:loadFromJson\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Soroban/Responses/SimulateTransactionResult.php
+
+		-
+			message: '#^Call to an undefined method Iterator\<mixed, mixed\>\:\:append\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Soneso/StellarSDK/Soroban/Responses/SimulateTransactionResults.php
+
+		-
+			message: '#^Call to an undefined method Iterator\<mixed, mixed\>\:\:count\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Soneso/StellarSDK/Soroban/Responses/SimulateTransactionResults.php
+
+		-
+			message: '#^Class Soneso\\StellarSDK\\Soroban\\Responses\\SimulateTransactionResults extends generic class IteratorIterator but does not specify its types\: TKey, TValue, TIterator$#'
+			identifier: missingType.generics
+			count: 1
+			path: Soneso/StellarSDK/Soroban/Responses/SimulateTransactionResults.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Soroban\\Responses\\SimulateTransactionResults\:\:add\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: Soneso/StellarSDK/Soroban/Responses/SimulateTransactionResults.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Soroban\\Responses\\SorobanRpcErrorResponse\:\:fromJson\(\) should return static\(Soneso\\StellarSDK\\Soroban\\Responses\\SorobanRpcErrorResponse\) but returns Soneso\\StellarSDK\\Soroban\\Responses\\SorobanRpcErrorResponse\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Soroban/Responses/SorobanRpcErrorResponse.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Soroban\\Responses\\TransactionEvents\:\:fromJson\(\) should return static\(Soneso\\StellarSDK\\Soroban\\Responses\\TransactionEvents\) but returns Soneso\\StellarSDK\\Soroban\\Responses\\TransactionEvents\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Soroban/Responses/TransactionEvents.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Soroban\\Responses\\TransactionInfo\:\:fromJson\(\) should return static\(Soneso\\StellarSDK\\Soroban\\Responses\\TransactionInfo\) but returns Soneso\\StellarSDK\\Soroban\\Responses\\TransactionInfo\.$#'
+			identifier: return.type
+			count: 1
+			path: Soneso/StellarSDK/Soroban/Responses/TransactionInfo.php
+
+		-
+			message: '#^Parameter \$args of method Soneso\\StellarSDK\\Soroban\\SorobanAuthorizedFunction\:\:forContractFunction\(\) has invalid type Soneso\\StellarSDK\\Soroban\\XdrSCVal\.$#'
+			identifier: class.notFound
+			count: 1
+			path: Soneso/StellarSDK/Soroban/SorobanAuthorizedFunction.php
+
+		-
+			message: '#^Instanceof between Soneso\\StellarSDK\\Soroban\\SorobanAuthorizedInvocation and Soneso\\StellarSDK\\Soroban\\SorobanAuthorizedInvocation will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
+			count: 1
+			path: Soneso/StellarSDK/Soroban/SorobanAuthorizedInvocation.php
+
+		-
+			message: '#^Instanceof between Soneso\\StellarSDK\\Soroban\\Responses\\LedgerEntry and Soneso\\StellarSDK\\Soroban\\Responses\\LedgerEntry will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
+			count: 1
+			path: Soneso/StellarSDK/Soroban/SorobanServer.php
+
+		-
+			message: '#^Method Soneso\\StellarSDK\\Soroban\\SorobanServer\:\:prepareRequest\(\) has parameter \$params with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Soneso/StellarSDK/Soroban/SorobanServer.php
+
+		-
+			message: '#^Instanceof between Soneso\\StellarSDK\\AbstractOperation and Soneso\\StellarSDK\\AbstractOperation will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
+			count: 2
+			path: Soneso/StellarSDK/Transaction.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between Soneso\\StellarSDK\\Xdr\\XdrPreconditions and null will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 1
+			path: Soneso/StellarSDK/Transaction.php
+
+		-
+			message: '#^PHPDoc tag @var has invalid value \(\$remainder BigInteger\)\: Unexpected token "\$remainder", expected type at offset 9 on line 1$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: Soneso/StellarSDK/Util/StellarAmount.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,11 @@
+includes:
+    - phpstan-baseline.neon
+
+parameters:
+    level: 6
+    paths:
+        - Soneso/StellarSDK
+    excludePaths:
+        # Generated XDR types are produced by tools/xdr-generator and validated
+        # by the round-trip test suite; they are not analysed here.
+        - Soneso/StellarSDK/Xdr


### PR DESCRIPTION
Improvements from a multi-perspective review of the hand-written SDK core (architecture, security, performance, code quality, testing). All changes are covered by unit tests and were reviewed individually; the full unit suite and PHPStan pass on every commit.

## Fixes

- KeyPair: signed payload signature hints (CAP-40) failed for payloads shorter than 4 bytes; key construction now validates that public and private keys are exactly 32 bytes instead of silently producing a corrupt account id.
- Memo: ids above PHP_INT_MAX (full unsigned 64-bit range) previously failed to decode and could not be created. `Memo::id` now also accepts unsigned decimal strings, and `getIdAsString` provides a uniform string representation.
- Asset: `Asset::TYPE_POOL_SHARE` was misspelled (`liquidty_pool_shares`) and could never match the asset type string Horizon returns; corrected to `liquidity_pool_shares`.
- Operation decoding: corrected copy-pasted error messages and misspelled private helpers in `AbstractOperation::fromXdr`.

## SEP services

- SEP-07 (URI scheme): signature verification reconstructs the signed payload by stripping at the signature parameter marker, independent of the signature's URL encoding.
- SEP-10 (web auth): challenge transactions without time bounds are rejected, as required by the spec; time bounds and the server signature are verified once per challenge instead of once per operation.
- SEP-01 (stellar.toml): `currencyFromUrl` accepts an optional HTTP client, like `fromDomain`.
- SEP-02 (federation): `resolveStellarAddress` uses the provided HTTP client for the stellar.toml fetch as well.
- SEP-31 (cross-border payments): a `transaction_info_needed` error response without a `fields` key is tolerated.

## Soroban contract client

- `ClientOptions`, `InstallRequest` and `DeployRequest` accept an optional preconfigured `SorobanServer`, enabling custom HTTP client configuration (mirrors the JS SDK's `ClientOptions.server`).
- Transaction status polling queries immediately after submission and retries with exponential backoff instead of always sleeping three seconds first.
- `checkMemoRequired` queries each payment destination account at most once.

## Performance

- `StellarAmount` reuses shared BigInteger constants instead of re-parsing them on every construction; `XdrEncoder` caches the endianness probe; XDR primitive codec hot paths avoid redundant decodes and allocations.
- SSE event streams are read in buffered chunks instead of one byte at a time, and reconnect cleanly when the stream closes mid-line.

## CI

- PHPStan (level 6, generated XDR excluded, baseline for existing findings) runs on every push and pull request; new findings fail CI.
- `composer audit` checks production dependencies for known security advisories on every push and pull request.

## Tests

- `SorobanClient` is now unit tested (was integration-only): construction, invocation, transaction building, install, deploy and spec loading with mocked RPC responses.
- Error-path unit tests added for SEP-10 web auth, federation, SEP-31 and stellar.toml loading.
- Live-network tests moved out of the unit suite; the unit suite runs fully offline.