### PR TITLE
Add SEP-35 operation IDs (TOID)

### DIFF
--- a/Soneso/StellarSDK/SEP/TOID/TOID.php
+++ b/Soneso/StellarSDK/SEP/TOID/TOID.php
@@ -1,0 +1,243 @@
+<?php declare(strict_types=1);
+
+// Copyright 2026 The Stellar PHP SDK Authors. All rights reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+namespace Soneso\StellarSDK\SEP\TOID;
+
+use InvalidArgumentException;
+use OverflowException;
+
+/**
+ * SEP-35 operation ID (also known as Horizon's "TOID": total order ID).
+ *
+ * SEP-35 defines the ID scheme used for Stellar operations in historical ledger data.
+ * An ID is a single signed 64-bit integer that packs three big-endian bit fields:
+ * a 32-bit ledger sequence, a 20-bit transaction application order, and a 12-bit
+ * operation index, encoded as
+ * `id = (ledgerSequence << 32) | (transactionOrder << 12) | operationIndex`.
+ * The sign bit of the encoded value is never set for valid field values, which keeps
+ * IDs usable directly as SQL bigint primary keys and cursors.
+ *
+ * IDs are represented with PHP's native int type, which requires a 64-bit PHP build;
+ * this SDK assumes a 64-bit build throughout.
+ *
+ * On the network, transaction application order and operation index are assigned
+ * starting at 1. Nonetheless, this class accepts 0 for both fields, since 0 is a
+ * valid encoded value and is required to express range boundaries such as
+ * `new TOID($ledgerSequence, 0, 0)`. Ledger sequence 0 is accepted for the same
+ * reason by the constructor and by {@see TOID::afterLedger()}. {@see
+ * TOID::ledgerRangeInclusive()} is stricter: it requires `$from >= 1`, because the
+ * network's first ledger is 1 and a smaller range start is a caller error rather than
+ * a valid boundary. Separately, that method special-cases `$from === 1` by pulling the
+ * computed range start down to 0, so that IDs encoded with ledger field 0 still fall
+ * inside the lowest range.
+ *
+ * @package Soneso\StellarSDK\SEP\TOID
+ * @see https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0035.md
+ * @see TOIDRange
+ */
+class TOID
+{
+    /**
+     * Largest ledger sequence encodable in the 32-bit ledger sequence field.
+     */
+    public const MAX_LEDGER_SEQUENCE = 2147483647;
+
+    /**
+     * Largest transaction application order encodable in the 20-bit field.
+     */
+    public const MAX_TRANSACTION_ORDER = 1048575;
+
+    /**
+     * Largest operation index encodable in the 12-bit field.
+     */
+    public const MAX_OPERATION_INDEX = 4095;
+
+    private int $ledgerSequence;
+    private int $transactionOrder;
+    private int $operationIndex;
+
+    /**
+     * @param int $ledgerSequence the ledger the operation was validated in, between 0 and 2147483647
+     * @param int $transactionOrder the application order of the transaction within the ledger, between 0 and 1048575
+     * @param int $operationIndex the index of the operation within the transaction, between 0 and 4095
+     *
+     * @throws InvalidArgumentException if any field is outside of its valid encoding range
+     */
+    public function __construct(int $ledgerSequence, int $transactionOrder, int $operationIndex)
+    {
+        if ($ledgerSequence < 0 || $ledgerSequence > self::MAX_LEDGER_SEQUENCE) {
+            throw new InvalidArgumentException(
+                'Invalid ledger sequence, it must be between 0 and ' . self::MAX_LEDGER_SEQUENCE . '.'
+            );
+        }
+        if ($transactionOrder < 0 || $transactionOrder > self::MAX_TRANSACTION_ORDER) {
+            throw new InvalidArgumentException(
+                'Invalid transaction order, it must be between 0 and ' . self::MAX_TRANSACTION_ORDER . '.'
+            );
+        }
+        if ($operationIndex < 0 || $operationIndex > self::MAX_OPERATION_INDEX) {
+            throw new InvalidArgumentException(
+                'Invalid operation index, it must be between 0 and ' . self::MAX_OPERATION_INDEX . '.'
+            );
+        }
+
+        $this->ledgerSequence = $ledgerSequence;
+        $this->transactionOrder = $transactionOrder;
+        $this->operationIndex = $operationIndex;
+    }
+
+    /**
+     * Returns the ledger sequence field.
+     *
+     * @return int the ledger the operation was validated in, between 0 and 2147483647
+     */
+    public function getLedgerSequence(): int
+    {
+        return $this->ledgerSequence;
+    }
+
+    /**
+     * Returns the transaction application order field.
+     *
+     * @return int the order of the transaction within the ledger, between 0 and 1048575
+     */
+    public function getTransactionOrder(): int
+    {
+        return $this->transactionOrder;
+    }
+
+    /**
+     * Returns the operation index field.
+     *
+     * @return int the index of the operation within the transaction, between 0 and 4095
+     */
+    public function getOperationIndex(): int
+    {
+        return $this->operationIndex;
+    }
+
+    /**
+     * Encodes the three fields into a single signed 64-bit integer, as defined by SEP-35.
+     *
+     * @return int the encoded ID: `(ledgerSequence << 32) | (transactionOrder << 12) | operationIndex`
+     */
+    public function toInt64(): int
+    {
+        return ($this->ledgerSequence << 32) | ($this->transactionOrder << 12) | $this->operationIndex;
+    }
+
+    /**
+     * Decodes a signed 64-bit encoded ID into its three fields.
+     *
+     * The ledger sequence is the top 32 bits, `$value >> 32`; the transaction order is
+     * the next 20 bits, `($value >> 12) & 0xFFFFF`; and the operation index is the
+     * bottom 12 bits, `$value & 0xFFF`. PHP's native int cannot exceed 2^63 - 1, so
+     * there is no separate upper bound check: any non-negative int decodes into field
+     * values that already satisfy the constructor's valid ranges.
+     *
+     * @param int $value the encoded ID to decode
+     * @return TOID the decoded ID
+     *
+     * @throws InvalidArgumentException if $value is negative. A negative value has its
+     *     sign bit set, which is never valid for an encoded ID, and right-shifting it
+     *     would otherwise produce a ledger sequence outside of the encoding domain.
+     */
+    public static function fromInt64(int $value): TOID
+    {
+        if ($value < 0) {
+            throw new InvalidArgumentException('Invalid encoded ID, it must not be negative.');
+        }
+
+        $ledgerSequence = $value >> 32;
+        $transactionOrder = ($value >> 12) & 0xFFFFF;
+        $operationIndex = $value & 0xFFF;
+
+        return new TOID($ledgerSequence, $transactionOrder, $operationIndex);
+    }
+
+    /**
+     * Advances this ID to the next operation slot, for use as a cursor while iterating.
+     *
+     * The operation index is incremented. When it is already at its maximum value of
+     * 4095, it is reset to 0 and the ledger sequence is incremented instead; the
+     * transaction application order is left unchanged in both cases, since the next
+     * operation slot after the last operation index of a transaction is not known to
+     * belong to any particular later transaction.
+     *
+     * @throws OverflowException if the operation index is already 4095 and the ledger
+     *     sequence is already 2147483647. Incrementing further would require a state
+     *     that the constructor would reject, and encoding it would set the sign bit.
+     */
+    public function incrementOperationIndex(): void
+    {
+        if ($this->operationIndex === self::MAX_OPERATION_INDEX) {
+            if ($this->ledgerSequence === self::MAX_LEDGER_SEQUENCE) {
+                throw new OverflowException(
+                    'Cannot increment operation index, the largest encodable ID has already been reached.'
+                );
+            }
+            $this->operationIndex = 0;
+            $this->ledgerSequence++;
+        } else {
+            $this->operationIndex++;
+        }
+    }
+
+    /**
+     * Returns the largest encodable ID within the given ledger.
+     *
+     * This is useful as an inclusive upper query bound: compare candidate IDs with
+     * `<=` against the result. This is the opposite convention from {@see
+     * TOID::ledgerRangeInclusive()}, whose end value is exclusive and must be compared
+     * with `<`.
+     *
+     * @param int $ledgerSequence the ledger sequence, between 0 and 2147483647
+     * @return TOID the ID `($ledgerSequence, 1048575, 4095)`
+     *
+     * @throws InvalidArgumentException if $ledgerSequence is outside of its valid range
+     */
+    public static function afterLedger(int $ledgerSequence): TOID
+    {
+        return new TOID($ledgerSequence, self::MAX_TRANSACTION_ORDER, self::MAX_OPERATION_INDEX);
+    }
+
+    /**
+     * Returns the range of encoded IDs covering ledgers $from through $to, inclusive.
+     *
+     * The range start is `(new TOID($from, 0, 0))->toInt64()`, except when `$from`
+     * is 1, in which case the start is 0 instead, so that the range also covers any
+     * ID encoded with ledger field 0. The range end is
+     * `(new TOID($to + 1, 0, 0))->toInt64()` and is exclusive: callers must compare
+     * candidate IDs with `<` against it, not `<=`.
+     *
+     * @param int $from the first ledger sequence to include, at least 1
+     * @param int $to the last ledger sequence to include
+     * @return TOIDRange the ID range covering ledgers $from through $to
+     *
+     * @throws InvalidArgumentException if $from is greater than $to, if $from is less
+     *     than 1, or if $to is not strictly less than 2147483647 (the range end is
+     *     computed from `$to + 1`, which must still fit within the ledger sequence field)
+     */
+    public static function ledgerRangeInclusive(int $from, int $to): TOIDRange
+    {
+        if ($from > $to) {
+            throw new InvalidArgumentException('Invalid range, from must not be greater than to.');
+        }
+        if ($from < 1) {
+            throw new InvalidArgumentException('Invalid range start, it must be at least 1.');
+        }
+        if ($to >= self::MAX_LEDGER_SEQUENCE) {
+            throw new InvalidArgumentException(
+                'Invalid range end, it must be less than ' . self::MAX_LEDGER_SEQUENCE . '.'
+            );
+        }
+
+        $start = $from === 1 ? 0 : (new TOID($from, 0, 0))->toInt64();
+        $end = (new TOID($to + 1, 0, 0))->toInt64();
+
+        return new TOIDRange($start, $end);
+    }
+}

--- a/Soneso/StellarSDK/SEP/TOID/TOIDRange.php
+++ b/Soneso/StellarSDK/SEP/TOID/TOIDRange.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types=1);
+
+// Copyright 2026 The Stellar PHP SDK Authors. All rights reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+namespace Soneso\StellarSDK\SEP\TOID;
+
+/**
+ * An inclusive-start, exclusive-end range of encoded SEP-35 operation IDs.
+ *
+ * This value class is returned by {@see TOID::ledgerRangeInclusive()} to describe the
+ * span of encoded 64-bit ID values that correspond to a range of ledgers. The start
+ * value is inclusive and the end value is exclusive, so callers should filter with
+ * `start <= id < end` when using this range to bound a query.
+ *
+ * @package Soneso\StellarSDK\SEP\TOID
+ * @see https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0035.md
+ * @see TOID
+ */
+class TOIDRange
+{
+    private int $start;
+    private int $end;
+
+    /**
+     * @param int $start the inclusive lower bound of the range, as an encoded ID
+     * @param int $end the exclusive upper bound of the range, as an encoded ID
+     */
+    public function __construct(int $start, int $end)
+    {
+        $this->start = $start;
+        $this->end = $end;
+    }
+
+    /**
+     * Returns the inclusive lower bound of the range.
+     *
+     * @return int the smallest encoded ID that belongs to the range
+     */
+    public function getStart(): int
+    {
+        return $this->start;
+    }
+
+    /**
+     * Returns the exclusive upper bound of the range.
+     *
+     * @return int the smallest encoded ID that no longer belongs to the range
+     */
+    public function getEnd(): int
+    {
+        return $this->end;
+    }
+}

--- a/Soneso/StellarSDKTests/Unit/SEP/TOID/TOIDTest.php
+++ b/Soneso/StellarSDKTests/Unit/SEP/TOID/TOIDTest.php
@@ -1,0 +1,219 @@
+<?php declare(strict_types=1);
+
+// Copyright 2026 The Stellar PHP SDK Authors. All rights reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+namespace Soneso\StellarSDKTests\Unit\SEP\TOID;
+
+use InvalidArgumentException;
+use OverflowException;
+use PHPUnit\Framework\TestCase;
+use Soneso\StellarSDK\SEP\TOID\TOID;
+
+class TOIDTest extends TestCase
+{
+    public function testEncodeDecodeRoundTrip(): void
+    {
+        $cases = [
+            [0, 0, 0, 0],
+            [0, 0, 1, 1],
+            [0, 0, 4095, 4095],
+            [0, 1, 0, 4096],
+            [0, 1048575, 0, 4294963200],
+            [1, 0, 0, 4294967296],
+            [1, 0, 1, 4294967297],
+            [1, 1, 0, 4294971392],
+            [1, 1, 1, 4294971393],
+            [1234567, 89, 2000, 5302424890087376],
+            [2147483647, 0, 0, 9223372032559808512],
+            [2147483647, 1048575, 4095, PHP_INT_MAX],
+        ];
+
+        foreach ($cases as [$ledgerSequence, $transactionOrder, $operationIndex, $id]) {
+            $toid = new TOID($ledgerSequence, $transactionOrder, $operationIndex);
+            $this->assertSame($id, $toid->toInt64());
+
+            $decoded = TOID::fromInt64($id);
+            $this->assertSame($ledgerSequence, $decoded->getLedgerSequence());
+            $this->assertSame($transactionOrder, $decoded->getTransactionOrder());
+            $this->assertSame($operationIndex, $decoded->getOperationIndex());
+        }
+    }
+
+    public function testIncrementOperationIndexWithinTransaction(): void
+    {
+        $toid = new TOID(0, 0, 0);
+
+        $toid->incrementOperationIndex();
+        $this->assertSame(0, $toid->getLedgerSequence());
+        $this->assertSame(0, $toid->getTransactionOrder());
+        $this->assertSame(1, $toid->getOperationIndex());
+
+        $toid->incrementOperationIndex();
+        $this->assertSame(0, $toid->getLedgerSequence());
+        $this->assertSame(0, $toid->getTransactionOrder());
+        $this->assertSame(2, $toid->getOperationIndex());
+
+        $toid->incrementOperationIndex();
+        $this->assertSame(0, $toid->getLedgerSequence());
+        $this->assertSame(0, $toid->getTransactionOrder());
+        $this->assertSame(3, $toid->getOperationIndex());
+    }
+
+    public function testIncrementOperationIndexRollsOverToNextLedger(): void
+    {
+        $toid = new TOID(0, 0, 4095);
+
+        $toid->incrementOperationIndex();
+        $this->assertSame(1, $toid->getLedgerSequence());
+        $this->assertSame(0, $toid->getTransactionOrder());
+        $this->assertSame(0, $toid->getOperationIndex());
+
+        $toid->incrementOperationIndex();
+        $this->assertSame(1, $toid->getLedgerSequence());
+        $this->assertSame(0, $toid->getTransactionOrder());
+        $this->assertSame(1, $toid->getOperationIndex());
+    }
+
+    public function testIncrementOperationIndexPreservesTransactionOrderAcrossRollover(): void
+    {
+        $toid = new TOID(5, 7, 4095);
+
+        $toid->incrementOperationIndex();
+        $this->assertSame(6, $toid->getLedgerSequence());
+        $this->assertSame(7, $toid->getTransactionOrder());
+        $this->assertSame(0, $toid->getOperationIndex());
+    }
+
+    public function testIncrementOperationIndexRollsOverIntoMaxLedgerSequence(): void
+    {
+        $toid = new TOID(2147483646, 0, 4095);
+
+        $toid->incrementOperationIndex();
+        $this->assertSame(2147483647, $toid->getLedgerSequence());
+        $this->assertSame(0, $toid->getTransactionOrder());
+        $this->assertSame(0, $toid->getOperationIndex());
+        $this->assertSame(9223372032559808512, $toid->toInt64());
+    }
+
+    public function testIncrementOperationIndexBelowCeilingAtMaxLedgerSequenceDoesNotThrow(): void
+    {
+        $toid = new TOID(2147483647, 7, 4094);
+
+        $toid->incrementOperationIndex();
+        $this->assertSame(2147483647, $toid->getLedgerSequence());
+        $this->assertSame(7, $toid->getTransactionOrder());
+        $this->assertSame(4095, $toid->getOperationIndex());
+    }
+
+    public function testIncrementOperationIndexThrowsAtCeiling(): void
+    {
+        $toid = new TOID(2147483647, 0, 4095);
+
+        $this->expectException(OverflowException::class);
+        $toid->incrementOperationIndex();
+    }
+
+    public function testAfterLedger(): void
+    {
+        $this->assertSame(4294967295, TOID::afterLedger(0)->toInt64());
+        $this->assertSame(8589934591, TOID::afterLedger(1)->toInt64());
+        $this->assertSame(433791696895, TOID::afterLedger(100)->toInt64());
+    }
+
+    public function testLedgerRangeInclusive(): void
+    {
+        $cases = [
+            [1, 1, 0, 8589934592],
+            [1, 2, 0, 12884901888],
+            [2, 2, 8589934592, 12884901888],
+            [2, 3, 8589934592, 17179869184],
+        ];
+
+        foreach ($cases as [$from, $to, $start, $end]) {
+            $range = TOID::ledgerRangeInclusive($from, $to);
+            $this->assertSame($start, $range->getStart());
+            $this->assertSame($end, $range->getEnd());
+        }
+    }
+
+    public function testConstructorRejectsNegativeLedgerSequence(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new TOID(-1, 0, 0);
+    }
+
+    public function testConstructorRejectsLedgerSequenceAboveMaximum(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new TOID(2147483648, 0, 0);
+    }
+
+    public function testConstructorRejectsNegativeTransactionOrder(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new TOID(0, -1, 0);
+    }
+
+    public function testConstructorRejectsTransactionOrderAboveMaximum(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new TOID(0, 1048576, 0);
+    }
+
+    public function testConstructorRejectsNegativeOperationIndex(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new TOID(0, 0, -1);
+    }
+
+    public function testConstructorRejectsOperationIndexAboveMaximum(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new TOID(0, 0, 4096);
+    }
+
+    public function testFromInt64RejectsNegativeOne(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        TOID::fromInt64(-1);
+    }
+
+    public function testFromInt64RejectsPhpIntMin(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        TOID::fromInt64(PHP_INT_MIN);
+    }
+
+    public function testLedgerRangeInclusiveRejectsFromGreaterThanTo(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        TOID::ledgerRangeInclusive(2, 1);
+    }
+
+    public function testLedgerRangeInclusiveRejectsFromBelowOne(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        TOID::ledgerRangeInclusive(0, 1);
+    }
+
+    public function testLedgerRangeInclusiveRejectsNegativeFrom(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        TOID::ledgerRangeInclusive(-1, 100);
+    }
+
+    public function testLedgerRangeInclusiveRejectsToAtLedgerSequenceMaximum(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid range end, it must be less than 2147483647.');
+        TOID::ledgerRangeInclusive(1, 2147483647);
+    }
+
+    public function testLedgerRangeInclusiveRejectsToAboveLedgerSequenceMaximum(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        TOID::ledgerRangeInclusive(1, 2147483648);
+    }
+}

--- a/compatibility/sep/SEP-0035_COMPATIBILITY_MATRIX.md
+++ b/compatibility/sep/SEP-0035_COMPATIBILITY_MATRIX.md
@@ -1,0 +1,41 @@
+# SEP-35: Operation IDs
+
+**Status:** ✅ Supported  
+**SDK Version:** 1.12.0  
+**Generated:** 2026-08-17 04:13 UTC  
+**Spec:** [https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0035.md](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0035.md)
+
+## Overall Coverage
+
+**Total Coverage:** 100.0% (7/7 fields)
+
+- ✅ **Implemented:** 7/7
+- ❌ **Not Implemented:** 0/7
+
+## Coverage by Section
+
+| Section | Coverage | Implemented | Total |
+|---------|----------|-------------|-------|
+| ID Encoding | 100.0% | 3 | 3 |
+| Cursor and Range Helpers | 100.0% | 4 | 4 |
+
+## ID Encoding
+
+SEP-35 ID construction and 64-bit integer encoding on TOID
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| `constructor` | ✅ Supported | `TOID.__construct()` |
+| `toInt64` | ✅ Supported | `TOID.toInt64()` |
+| `fromInt64` | ✅ Supported | `TOID.fromInt64()` |
+
+## Cursor and Range Helpers
+
+SEP-35 pagination cursor and ledger range utilities
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| `incrementOperationIndex` | ✅ Supported | `TOID.incrementOperationIndex()` |
+| `afterLedger` | ✅ Supported | `TOID.afterLedger()` |
+| `ledgerRangeInclusive` | ✅ Supported | `TOID.ledgerRangeInclusive()` |
+| `TOIDRange` | ✅ Supported | `TOIDRange` |

--- a/tools/matrix-generator/README.md
+++ b/tools/matrix-generator/README.md
@@ -10,7 +10,7 @@ There are three independent generators, one per domain:
 |-----------|-----------------|--------|
 | **Horizon** | SDK RequestBuilder classes vs. Horizon REST API endpoints | `compatibility/horizon/COMPATIBILITY_MATRIX.md` |
 | **RPC** | SDK SorobanServer class vs. Stellar RPC JSON-RPC methods | `compatibility/rpc/RPC_COMPATIBILITY_MATRIX.md` |
-| **SEP** | SDK implementations vs. 20 Stellar Ecosystem Proposals | `compatibility/sep/SEP-XXXX_COMPATIBILITY_MATRIX.md` (one per SEP) |
+| **SEP** | SDK implementations vs. 21 Stellar Ecosystem Proposals | `compatibility/sep/SEP-XXXX_COMPATIBILITY_MATRIX.md` (one per SEP) |
 
 Each generator reads the SDK source tree, fetches the latest upstream specification from GitHub (Horizon router, RPC handler code, or SEP documents), and produces a coverage percentage with a detailed breakdown.
 
@@ -64,7 +64,7 @@ Generate a single SEP matrix:
 python tools/matrix-generator/sep/generate_sep_matrix.py --sep 10
 ```
 
-Generate all supported SEPs (currently 20 SEP analyzers):
+Generate all supported SEPs (currently 21 SEP analyzers):
 
 ```bash
 python tools/matrix-generator/sep/generate_sep_matrix.py --all
@@ -94,7 +94,7 @@ tools/matrix-generator/
     extract_rpc_methods.py       # Extracts RPC specs from GitHub
     generate_rpc_matrix.py       # RPC method comparator
   sep/
-    generate_sep_matrix.py       # SEP analyzers (all 20 in one file)
+    generate_sep_matrix.py       # SEP analyzers (all 21 in one file)
 ```
 
 Output goes to:
@@ -103,7 +103,7 @@ Output goes to:
 compatibility/
   horizon/COMPATIBILITY_MATRIX.md
   rpc/RPC_COMPATIBILITY_MATRIX.md
-  sep/SEP-XXXX_COMPATIBILITY_MATRIX.md  (x20)
+  sep/SEP-XXXX_COMPATIBILITY_MATRIX.md  (x21)
 ```
 
 ## How It Works

--- a/tools/matrix-generator/sep/generate_sep_matrix.py
+++ b/tools/matrix-generator/sep/generate_sep_matrix.py
@@ -1911,6 +1911,67 @@ class SEP31Analyzer(SEPAnalyzerBase):
 
 
 # ===========================================================================
+# SEP-35: Operation IDs
+# ===========================================================================
+
+class SEP35Analyzer(SEPAnalyzerBase):
+    sep_number = 35
+    sep_title = "Operation IDs"
+    sep_url = "https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0035.md"
+
+    def analyze(self) -> CompatibilityMatrix:
+        matrix = self._make_matrix()
+
+        toid_members = self.sdk.get_class_members("TOID")
+
+        # Read TOID source to verify range-boundary behavior
+        toid_path = self.sdk.find_class("TOID")
+        toid_src = toid_path.read_text(encoding="utf-8") if toid_path else ""
+
+        # -- ID Encoding --
+        encoding_section = SEPSection(
+            name="ID Encoding",
+            description="SEP-35 ID construction and 64-bit integer encoding on TOID",
+        )
+        encoding_section.fields = [
+            self._field("constructor", "Construct a TOID from ledger sequence, transaction order, and operation index fields",
+                        "__construct" in toid_members,
+                        sdk_class="TOID.__construct()"),
+            self._field("toInt64", "Encode the three fields into a single signed 64-bit integer ID",
+                        "toInt64" in toid_members and "($this->ledgerSequence << 32) | ($this->transactionOrder << 12) | $this->operationIndex" in toid_src,
+                        sdk_class="TOID.toInt64()"),
+            self._field("fromInt64", "Decode a signed 64-bit integer ID back into its three fields",
+                        "fromInt64" in toid_members and "$ledgerSequence = $value >> 32;" in toid_src and "$transactionOrder = ($value >> 12) & 0xFFFFF;" in toid_src,
+                        sdk_class="TOID.fromInt64()"),
+        ]
+
+        # -- Cursor and Range Helpers --
+        cursor_section = SEPSection(
+            name="Cursor and Range Helpers",
+            description="SEP-35 pagination cursor and ledger range utilities",
+        )
+        cursor_section.fields = [
+            self._field("incrementOperationIndex", "Advance an ID to the next operation slot, for use as a pagination cursor",
+                        "incrementOperationIndex" in toid_members and "MAX_OPERATION_INDEX" in toid_src and "ledgerSequence++" in toid_src,
+                        sdk_class="TOID.incrementOperationIndex()"),
+            self._field("afterLedger", "Return the largest encodable ID within a given ledger, for use as an inclusive upper query bound",
+                        "afterLedger" in toid_members and "new TOID($ledgerSequence, self::MAX_TRANSACTION_ORDER, self::MAX_OPERATION_INDEX)" in toid_src,
+                        sdk_class="TOID.afterLedger()"),
+            self._field("ledgerRangeInclusive", "Return the range of encoded IDs covering a span of ledgers, with an exclusive range end",
+                        "ledgerRangeInclusive" in toid_members and "$end = (new TOID($to + 1, 0, 0))->toInt64();" in toid_src,
+                        sdk_class="TOID.ledgerRangeInclusive()"),
+            self._field("TOIDRange", "Value class pairing a range start and end as encoded IDs",
+                        self.sdk.class_exists("TOIDRange"),
+                        sdk_class="TOIDRange"),
+        ]
+
+        sections = [encoding_section, cursor_section]
+        matrix.sections = sections
+        matrix.overall_status = self._overall(sections)
+        return matrix
+
+
+# ===========================================================================
 # SEP-38: Anchor RFQ API
 # ===========================================================================
 
@@ -3112,6 +3173,7 @@ class SEPAnalyzerFactory:
         24: SEP24Analyzer,
         30: SEP30Analyzer,
         31: SEP31Analyzer,
+        35: SEP35Analyzer,
         38: SEP38Analyzer,
         45: SEP45Analyzer,
         46: SEP46Analyzer,


### PR DESCRIPTION
Adds SEP-35 operation ID support to the SDK. A new `TOID` class in `Soneso/StellarSDK/SEP/TOID` encodes and decodes the 64-bit operation ID scheme Horizon uses for historical ledger data, along with cursor and ledger range helpers. Documentation is at `docs/sep/sep-35.md`.