### PR TITLE
Resolve CAP-85 external reference executables when loading contracts

### DIFF
--- a/Soneso/StellarSDK/Soroban/SorobanServer.php
+++ b/Soneso/StellarSDK/Soroban/SorobanServer.php
@@ -37,12 +37,18 @@ use Soneso\StellarSDK\Transaction;
 use Soneso\StellarSDK\Xdr\XdrAccountID;
 use Soneso\StellarSDK\Xdr\XdrContractCodeEntry;
 use Soneso\StellarSDK\Xdr\XdrContractDataDurability;
+use Soneso\StellarSDK\Xdr\XdrContractExecutableExternalRef;
+use Soneso\StellarSDK\Xdr\XdrContractExecutableType;
 use Soneso\StellarSDK\Xdr\XdrLedgerEntryType;
 use Soneso\StellarSDK\Xdr\XdrLedgerKey;
 use Soneso\StellarSDK\Xdr\XdrLedgerKeyAccount;
 use Soneso\StellarSDK\Xdr\XdrLedgerKeyContractCode;
 use Soneso\StellarSDK\Xdr\XdrLedgerKeyContractData;
+use Soneso\StellarSDK\Xdr\XdrSCAddressType;
 use Soneso\StellarSDK\Xdr\XdrSCVal;
+use Soneso\StellarSDK\Xdr\XdrSCValType;
+use Exception;
+use InvalidArgumentException;
 use UnexpectedValueException;
 
 /**
@@ -409,11 +415,16 @@ class SorobanServer
     /**
      * Loads the contract source code for a given contract id
      *
-     * First retrieves the contract instance data to determine the wasm id, then loads
-     * the contract code entry containing the compiled WASM bytecode.
+     * Reads the contract instance from the ledger and loads the code entry for its
+     * executable. A wasm executable is loaded by its wasm id directly; a CAP-85 external
+     * reference is first resolved to its wasm id via loadWasmIdForExternalRef(). A Stellar
+     * asset contract has no wasm code, so it yields null.
      *
      * @param string $contractId The contract id (C-prefixed address) of the deployed contract
      * @return XdrContractCodeEntry|null The contract code entry if found, null if not found
+     * @throws InvalidArgumentException If the instance carries an external reference whose
+     * owner is not a contract address or whose tag entry does not hold a 32-byte wasm hash
+     * @throws Exception If an external reference owner carries an unknown address type
      * @throws GuzzleException If the RPC request fails
      */
     public function loadContractCodeForContractId(string $contractId) : ?XdrContractCodeEntry {
@@ -426,9 +437,23 @@ class SorobanServer
         $ledgerEntries = $this->getLedgerEntries([$ledgerKey->toBase64Xdr()]);
         if ($ledgerEntries->entries !== null && count($ledgerEntries->entries) > 0) {
             $ledgerEntryData = $ledgerEntries->entries[0]->getLedgerEntryDataXdr();
-            if ($ledgerEntryData->contractData !== null && $ledgerEntryData->contractData->val->instance?->executable->wasmIdHex !== null) {
-                $wasmId = $ledgerEntryData->contractData->val->instance->executable->wasmIdHex;
-                return $this->loadContractCodeForWasmId($wasmId);
+            $executable = $ledgerEntryData->contractData?->val->instance?->executable;
+            if ($executable !== null) {
+                switch ($executable->type->value) {
+                    case XdrContractExecutableType::CONTRACT_EXECUTABLE_WASM:
+                        if ($executable->wasmIdHex !== null) {
+                            return $this->loadContractCodeForWasmId($executable->wasmIdHex);
+                        }
+                        break;
+                    case XdrContractExecutableType::CONTRACT_EXECUTABLE_EXTERNAL_REF:
+                        if ($executable->externalRef !== null) {
+                            $wasmId = $this->loadWasmIdForExternalRef($executable->externalRef);
+                            if ($wasmId !== null) {
+                                return $this->loadContractCodeForWasmId($wasmId);
+                            }
+                        }
+                        break;
+                }
             }
         }
         return null;
@@ -444,6 +469,9 @@ class SorobanServer
      * @param string $contractId The contract id (C-prefixed address) of the deployed contract
      * @return SorobanContractInfo|null The parsed contract information or null if contract not found
      * @throws SorobanContractParserException If parsing the WASM bytecode fails
+     * @throws InvalidArgumentException If the instance carries an external reference whose
+     * owner is not a contract address or whose tag entry does not hold a 32-byte wasm hash
+     * @throws Exception If an external reference owner carries an unknown address type
      * @throws GuzzleException If the RPC request fails
      */
     public function loadContractInfoForContractId(string $contractId) :?SorobanContractInfo {
@@ -474,6 +502,54 @@ class SorobanServer
         }
         $byteCode = $contractCodeEntry->code->value;
         return SorobanContractParser::parseContractByteCode($byteCode);
+    }
+
+    /**
+     * Resolves a CAP-85 external reference to the wasm id of the code it names
+     *
+     * An external reference identifies executable code indirectly: it names an owner
+     * contract and a tag, and the owner holds a persistent contract data entry keyed by
+     * that tag whose value is the 32-byte hash of an already uploaded wasm. A contract
+     * instance created from such a reference runs that code. This method reads the tag
+     * entry off the ledger; the owner contract is not invoked.
+     *
+     * The tag is matched byte for byte, so it is passed through exactly as the reference
+     * carries it.
+     *
+     * @param XdrContractExecutableExternalRef $ref The external reference naming the owner contract and the tag
+     * @return string|null The hex-encoded wasm id the tag entry holds, or null if no tag entry exists on the owner
+     * @throws InvalidArgumentException If the owner is not a contract address, or the tag
+     * entry exists but does not hold a 32-byte wasm hash
+     * @throws Exception If the owner address carries an unknown address type
+     * @throws GuzzleException If the RPC request fails
+     */
+    public function loadWasmIdForExternalRef(XdrContractExecutableExternalRef $ref): ?string {
+        if ($ref->executableOwner->type->value !== XdrSCAddressType::SC_ADDRESS_TYPE_CONTRACT) {
+            throw new InvalidArgumentException(
+                "External reference owner " . $ref->executableOwner->toStrKey()
+                . " is not a contract address; only a contract can hold the executable tag entry");
+        }
+        $entry = $this->getContractData(
+            $ref->executableOwner->getCanonicalContractIdHex(),
+            XdrSCVal::forExecutableTag($ref->tag),
+            XdrContractDataDurability::PERSISTENT());
+        if ($entry === null) {
+            return null;
+        }
+        $contractData = $entry->getLedgerEntryDataXdr()->contractData;
+        if ($contractData === null) {
+            throw new InvalidArgumentException(
+                "The executable tag entry on contract " . $ref->executableOwner->toStrKey()
+                . " is not a contract data ledger entry");
+        }
+        $val = $contractData->val;
+        $bytes = $val->type->value === XdrSCValType::SCV_BYTES ? $val->bytes?->getValue() : null;
+        if ($bytes === null || strlen($bytes) !== 32) {
+            throw new InvalidArgumentException(
+                "The executable tag entry on contract " . $ref->executableOwner->toStrKey()
+                . " does not hold a 32-byte wasm hash");
+        }
+        return bin2hex($bytes);
     }
 
     /**

--- a/Soneso/StellarSDKTests/Integration/P28ExternalRefExecutableTest.php
+++ b/Soneso/StellarSDKTests/Integration/P28ExternalRefExecutableTest.php
@@ -1,0 +1,126 @@
+<?php declare(strict_types=1);
+
+// Copyright 2026 The Stellar PHP SDK Authors. All rights reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+namespace Soneso\StellarSDKTests\Integration;
+
+use PHPUnit\Framework\TestCase;
+use Soneso\StellarSDK\Crypto\StrKey;
+use Soneso\StellarSDK\Soroban\SorobanServer;
+use Soneso\StellarSDK\Xdr\XdrContractDataDurability;
+use Soneso\StellarSDK\Xdr\XdrContractExecutableType;
+use Soneso\StellarSDK\Xdr\XdrSCVal;
+use Soneso\StellarSDKTests\PrintLogger;
+use Throwable;
+
+/**
+ * Protocol 28 (CAP-85) external reference executable read-path integration test.
+ *
+ * Reads a contract whose instance carries an external reference executable and verifies
+ * that the reference resolves to the owning contract's tag entry, the wasm id it holds,
+ * and the contract code and parsed spec behind that wasm id.
+ *
+ * The test covers the read path only: writing an executable tag entry needs an owner
+ * contract that exposes a tag-writing function, and no such contract ships with this
+ * repo's test fixtures. The fixture constants below therefore name a contract that
+ * already exists on the network, and the test skips while they are unfilled.
+ */
+class P28ExternalRefExecutableTest extends TestCase
+{
+    const TESTNET_SERVER_URL = "https://soroban-testnet.stellar.org";
+
+    /** Contract id ("C...") of a contract created from an external reference. */
+    const EXTERNAL_REF_CONTRACT_ID = '';
+    /** Contract id ("C...") of the owner contract the reference names. */
+    const OWNER_CONTRACT_ID = '';
+    /** Tag under which the owner holds the executable tag entry. */
+    const EXECUTABLE_TAG = '';
+    /** Hex-encoded wasm id the tag entry is expected to resolve to. */
+    const EXPECTED_WASM_ID = '';
+    /** Name of a function the resolved contract spec is expected to export. */
+    const EXPECTED_FUNCTION_NAME = '';
+
+    /**
+     * Set to 'testnet' to run; any other value skips the test.
+     *
+     * This gate follows the same convention used throughout the integration suite.
+     */
+    private string $testOn = 'testnet';
+
+    private SorobanServer $server;
+
+    public function setUp(): void
+    {
+        error_reporting(E_ALL);
+        if ($this->testOn !== 'testnet') {
+            $this->markTestSkipped('P28 external ref integration test requires testnet access. '
+                . 'Set $testOn = "testnet" to enable.');
+        }
+        $this->server = new SorobanServer(self::TESTNET_SERVER_URL);
+        $this->server->setLogger(new PrintLogger());
+
+        try {
+            $protocolVersion = $this->server->getNetwork()->getProtocolVersion();
+        } catch (Throwable $t) {
+            $protocolVersion = null;
+        }
+        if ($protocolVersion === null || $protocolVersion < 28) {
+            $this->markTestSkipped('The network reports protocol '
+                . ($protocolVersion === null ? 'unavailable' : (string)$protocolVersion)
+                . '; external reference executables need protocol 28 '
+                . '(testnet upgrade scheduled for 2026-08-27).');
+        }
+
+        foreach ([
+            'EXTERNAL_REF_CONTRACT_ID' => self::EXTERNAL_REF_CONTRACT_ID,
+            'OWNER_CONTRACT_ID' => self::OWNER_CONTRACT_ID,
+            'EXECUTABLE_TAG' => self::EXECUTABLE_TAG,
+            'EXPECTED_WASM_ID' => self::EXPECTED_WASM_ID,
+            'EXPECTED_FUNCTION_NAME' => self::EXPECTED_FUNCTION_NAME,
+        ] as $name => $value) {
+            if ($value === '') {
+                $this->markTestSkipped('Fixture constant ' . $name . ' is unfilled; it needs '
+                    . 'an external reference contract deployed on testnet.');
+            }
+        }
+    }
+
+    public function testResolvesExternalRefExecutable(): void
+    {
+        // The instance entry must carry the external reference arm pointing at the
+        // expected owner and tag.
+        $instanceEntry = $this->server->getContractData(
+            StrKey::decodeContractIdHex(self::EXTERNAL_REF_CONTRACT_ID),
+            XdrSCVal::forLedgerKeyContractInstance(),
+            XdrContractDataDurability::PERSISTENT(),
+        );
+        $this->assertNotNull($instanceEntry);
+        $executable = $instanceEntry->getLedgerEntryDataXdr()->contractData?->val->instance?->executable;
+        $this->assertNotNull($executable);
+        $this->assertSame(XdrContractExecutableType::CONTRACT_EXECUTABLE_EXTERNAL_REF, $executable->type->value);
+        $ref = $executable->externalRef;
+        $this->assertNotNull($ref);
+        $this->assertSame(
+            StrKey::decodeContractIdHex(self::OWNER_CONTRACT_ID),
+            $ref->executableOwner->getCanonicalContractIdHex(),
+        );
+        $this->assertSame(self::EXECUTABLE_TAG, $ref->tag);
+
+        // The reference must resolve to the expected wasm id.
+        $this->assertSame(self::EXPECTED_WASM_ID, $this->server->loadWasmIdForExternalRef($ref));
+
+        // The loading paths must recover the code and its spec through the reference.
+        $codeEntry = $this->server->loadContractCodeForContractId(self::EXTERNAL_REF_CONTRACT_ID);
+        $this->assertNotNull($codeEntry);
+        $this->assertNotSame('', $codeEntry->code->value);
+
+        $info = $this->server->loadContractInfoForContractId(self::EXTERNAL_REF_CONTRACT_ID);
+        $this->assertNotNull($info);
+        $functionNames = array_map(static function ($func) {
+            return $func->name;
+        }, $info->funcs);
+        $this->assertContains(self::EXPECTED_FUNCTION_NAME, $functionNames);
+    }
+}

--- a/Soneso/StellarSDKTests/Unit/Soroban/SorobanServerTest.php
+++ b/Soneso/StellarSDKTests/Unit/Soroban/SorobanServerTest.php
@@ -10,8 +10,10 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
+use Soneso\StellarSDK\Crypto\StrKey;
 use Soneso\StellarSDK\Soroban\Address;
 use Soneso\StellarSDK\Soroban\Requests\GetEventsRequest;
 use Soneso\StellarSDK\Soroban\Requests\GetLedgersRequest;
@@ -36,7 +38,26 @@ use Soneso\StellarSDK\Network;
 use Soneso\StellarSDK\TransactionBuilder;
 use Soneso\StellarSDK\Account;
 use Soneso\StellarSDK\Crypto\KeyPair;
+use Soneso\StellarSDK\Xdr\XdrContractCodeEntry;
+use Soneso\StellarSDK\Xdr\XdrContractCodeEntryExt;
+use Soneso\StellarSDK\Xdr\XdrContractDataEntry;
+use Soneso\StellarSDK\Xdr\XdrContractExecutable;
+use Soneso\StellarSDK\Xdr\XdrDataValueMandatory;
+use Soneso\StellarSDK\Xdr\XdrExtensionPoint;
+use Soneso\StellarSDK\Xdr\XdrLedgerEntryData;
+use Soneso\StellarSDK\Xdr\XdrLedgerEntryType;
+use Soneso\StellarSDK\Xdr\XdrLedgerKey;
+use Soneso\StellarSDK\Xdr\XdrSCContractInstance;
+use Soneso\StellarSDK\Xdr\XdrSCEnvMetaEntry;
+use Soneso\StellarSDK\Xdr\XdrSCEnvMetaEntryInterfaceVersion;
+use Soneso\StellarSDK\Xdr\XdrSCEnvMetaKind;
+use Soneso\StellarSDK\Xdr\XdrSCSpecEntry;
+use Soneso\StellarSDK\Xdr\XdrSCSpecEntryKind;
+use Soneso\StellarSDK\Xdr\XdrSCSpecFunctionV0;
+use Soneso\StellarSDK\Xdr\XdrSCSpecType;
+use Soneso\StellarSDK\Xdr\XdrSCSpecTypeDef;
 use Soneso\StellarSDK\Xdr\XdrSCVal;
+use Soneso\StellarSDK\Xdr\XdrSCValType;
 use Soneso\StellarSDK\Xdr\XdrContractDataDurability;
 use Soneso\StellarSDK\PaymentOperationBuilder;
 use Soneso\StellarSDK\Asset;
@@ -57,15 +78,19 @@ class SorobanServerTest extends TestCase
     private const TEST_CONTRACT_ID = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM';
     private const TEST_WASM_ID = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855';
     private const TEST_TRANSACTION_HASH = 'a12b3c4d5e6f7890abcdef1234567890abcdef1234567890abcdef1234567890';
+    private const TEST_OWNER_CONTRACT_ID_HEX = 'c0decafec0decafec0decafec0decafec0decafec0decafec0decafec0decafe';
+    private const TEST_EXECUTABLE_TAG = 'token-v1';
 
     /**
      * Helper method to create a mocked SorobanServer with predefined responses
-     * Uses reflection to inject the mock HTTP client
+     * Uses reflection to inject the mock HTTP client. When a history container is
+     * passed, every request the server sends is recorded into it.
      */
-    private function createMockedSorobanServer(array $responses): SorobanServer
+    private function createMockedSorobanServer(array $responses, array &$requestHistory = []): SorobanServer
     {
         $mock = new MockHandler($responses);
         $handlerStack = HandlerStack::create($mock);
+        $handlerStack->push(Middleware::history($requestHistory));
         $client = new Client(['handler' => $handlerStack]);
 
         $server = new SorobanServer(self::TEST_ENDPOINT);
@@ -967,5 +992,337 @@ class SorobanServerTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Service URL must use HTTPS');
         new SorobanServer('http://soroban-testnet.stellar.org');
+    }
+
+    // External reference executable (CAP-85) tests
+
+    /**
+     * getLedgerEntries response containing the given ledger entry as its single result.
+     */
+    private function ledgerEntryResponse(XdrLedgerEntryData $entryData): Response
+    {
+        return new Response(200, [], json_encode([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'result' => [
+                'entries' => [
+                    [
+                        'key' => 'AAAABgAAAAA=',
+                        'xdr' => $entryData->toBase64Xdr(),
+                        'lastModifiedLedgerSeq' => 1000,
+                    ],
+                ],
+                'latestLedger' => 1000,
+            ]
+        ]));
+    }
+
+    /**
+     * getLedgerEntries response with no entries, as returned when the queried key does
+     * not exist on the ledger.
+     */
+    private function emptyLedgerEntriesResponse(): Response
+    {
+        return new Response(200, [], json_encode([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'result' => [
+                'entries' => [],
+                'latestLedger' => 1000,
+            ]
+        ]));
+    }
+
+    /**
+     * CONTRACT_DATA ledger entry holding the contract instance with a wasm executable.
+     */
+    private function wasmInstanceEntryData(string $wasmIdHex): XdrLedgerEntryData
+    {
+        return $this->instanceEntryData(XdrContractExecutable::forWasmId($wasmIdHex));
+    }
+
+    /**
+     * CONTRACT_DATA ledger entry holding the contract instance with an external
+     * reference executable pointing at the given owner contract and tag.
+     */
+    private function externalRefInstanceEntryData(string $ownerContractIdHex, string $tag): XdrLedgerEntryData
+    {
+        return $this->instanceEntryData(XdrContractExecutable::forExternalRef(
+            Address::fromContractId($ownerContractIdHex)->toXdr(),
+            $tag,
+        ));
+    }
+
+    private function instanceEntryData(XdrContractExecutable $executable): XdrLedgerEntryData
+    {
+        $dataEntry = new XdrContractDataEntry(
+            new XdrExtensionPoint(0),
+            Address::fromContractId(self::TEST_CONTRACT_ID)->toXdr(),
+            XdrSCVal::forLedgerKeyContractInstance(),
+            XdrContractDataDurability::PERSISTENT(),
+            XdrSCVal::forContractInstance(new XdrSCContractInstance($executable)),
+        );
+        $entryData = new XdrLedgerEntryData(XdrLedgerEntryType::CONTRACT_DATA());
+        $entryData->contractData = $dataEntry;
+        return $entryData;
+    }
+
+    /**
+     * CONTRACT_DATA ledger entry holding the executable tag entry on the owner
+     * contract: keyed by the tag, PERSISTENT, with the given value.
+     */
+    private function executableTagEntryData(string $ownerContractIdHex, string $tag, XdrSCVal $value): XdrLedgerEntryData
+    {
+        $dataEntry = new XdrContractDataEntry(
+            new XdrExtensionPoint(0),
+            Address::fromContractId($ownerContractIdHex)->toXdr(),
+            XdrSCVal::forExecutableTag($tag),
+            XdrContractDataDurability::PERSISTENT(),
+            $value,
+        );
+        $entryData = new XdrLedgerEntryData(XdrLedgerEntryType::CONTRACT_DATA());
+        $entryData->contractData = $dataEntry;
+        return $entryData;
+    }
+
+    /**
+     * CONTRACT_CODE ledger entry holding the given byte code under the given wasm hash.
+     */
+    private function contractCodeEntryData(string $wasmIdHex, string $byteCode): XdrLedgerEntryData
+    {
+        $codeEntry = new XdrContractCodeEntry(
+            new XdrContractCodeEntryExt(0),
+            hex2bin($wasmIdHex),
+            new XdrDataValueMandatory($byteCode),
+        );
+        $entryData = new XdrLedgerEntryData(XdrLedgerEntryType::CONTRACT_CODE());
+        $entryData->contractCode = $codeEntry;
+        return $entryData;
+    }
+
+    /**
+     * Synthetic contract byte code containing an env meta section followed by a spec
+     * section with a single function entry, as parsed by SorobanContractParser.
+     */
+    private function specTestByteCode(string $functionName): string
+    {
+        $envMeta = new XdrSCEnvMetaEntry(new XdrSCEnvMetaKind(XdrSCEnvMetaKind::SC_ENV_META_KIND_INTERFACE_VERSION));
+        $envMeta->interfaceVersion = new XdrSCEnvMetaEntryInterfaceVersion(23, 0);
+        $specEntry = new XdrSCSpecEntry(new XdrSCSpecEntryKind(XdrSCSpecEntryKind::SC_SPEC_ENTRY_FUNCTION_V0));
+        $specEntry->functionV0 = new XdrSCSpecFunctionV0(
+            '',
+            $functionName,
+            [],
+            [new XdrSCSpecTypeDef(XdrSCSpecType::VOID())],
+        );
+        return 'contractenvmetav0' . $envMeta->encode() . 'contractspecv0' . $specEntry->encode();
+    }
+
+    /**
+     * The ledger key of the recorded getLedgerEntries request at the given position.
+     */
+    private function requestedLedgerKey(array $requestHistory, int $index): XdrLedgerKey
+    {
+        $body = json_decode((string)$requestHistory[$index]['request']->getBody(), true);
+        $this->assertSame('getLedgerEntries', $body['method']);
+        $this->assertCount(1, $body['params']['keys']);
+        return XdrLedgerKey::fromBase64Xdr($body['params']['keys'][0]);
+    }
+
+    public function testLoadContractCodeForContractIdWasmArm(): void
+    {
+        $byteCode = 'test wasm byte code';
+        $server = $this->createMockedSorobanServer([
+            $this->ledgerEntryResponse($this->wasmInstanceEntryData(self::TEST_WASM_ID)),
+            $this->ledgerEntryResponse($this->contractCodeEntryData(self::TEST_WASM_ID, $byteCode)),
+        ]);
+
+        $codeEntry = $server->loadContractCodeForContractId(self::TEST_CONTRACT_ID);
+
+        $this->assertNotNull($codeEntry);
+        $this->assertSame($byteCode, $codeEntry->code->value);
+    }
+
+    public function testLoadContractCodeForContractIdExternalRefArm(): void
+    {
+        $byteCode = 'external ref wasm byte code';
+        $requestHistory = [];
+        $server = $this->createMockedSorobanServer([
+            $this->ledgerEntryResponse($this->externalRefInstanceEntryData(
+                self::TEST_OWNER_CONTRACT_ID_HEX, self::TEST_EXECUTABLE_TAG)),
+            $this->ledgerEntryResponse($this->executableTagEntryData(
+                self::TEST_OWNER_CONTRACT_ID_HEX, self::TEST_EXECUTABLE_TAG,
+                XdrSCVal::forBytes(hex2bin(self::TEST_WASM_ID)))),
+            $this->ledgerEntryResponse($this->contractCodeEntryData(self::TEST_WASM_ID, $byteCode)),
+        ], $requestHistory);
+
+        $codeEntry = $server->loadContractCodeForContractId(self::TEST_CONTRACT_ID);
+
+        $this->assertNotNull($codeEntry);
+        $this->assertSame($byteCode, $codeEntry->code->value);
+
+        $this->assertCount(3, $requestHistory);
+        $tagKey = $this->requestedLedgerKey($requestHistory, 1);
+        $this->assertSame(XdrLedgerEntryType::CONTRACT_DATA, $tagKey->type->value);
+        $this->assertNotNull($tagKey->contractData);
+        $this->assertSame(self::TEST_OWNER_CONTRACT_ID_HEX, $tagKey->contractData->contract->contractId);
+        $this->assertSame(XdrSCValType::SCV_EXECUTABLE_TAG, $tagKey->contractData->key->type->value);
+        $this->assertSame(self::TEST_EXECUTABLE_TAG, $tagKey->contractData->key->executableTag);
+        $this->assertSame(XdrContractDataDurability::PERSISTENT, $tagKey->contractData->durability->value);
+        $codeKey = $this->requestedLedgerKey($requestHistory, 2);
+        $this->assertNotNull($codeKey->contractCode);
+        $this->assertSame(self::TEST_WASM_ID, bin2hex($codeKey->contractCode->hash));
+    }
+
+    public function testExternalRefMissingTagEntryReturnsNull(): void
+    {
+        $directServer = $this->createMockedSorobanServer([$this->emptyLedgerEntriesResponse()]);
+        $ref = XdrContractExecutable::forExternalRef(
+            Address::fromContractId(self::TEST_OWNER_CONTRACT_ID_HEX)->toXdr(),
+            self::TEST_EXECUTABLE_TAG,
+        )->externalRef;
+        $this->assertNotNull($ref);
+        $this->assertNull($directServer->loadWasmIdForExternalRef($ref));
+
+        $loadServer = $this->createMockedSorobanServer([
+            $this->ledgerEntryResponse($this->externalRefInstanceEntryData(
+                self::TEST_OWNER_CONTRACT_ID_HEX, self::TEST_EXECUTABLE_TAG)),
+            $this->emptyLedgerEntriesResponse(),
+        ]);
+        $this->assertNull($loadServer->loadContractCodeForContractId(self::TEST_CONTRACT_ID));
+    }
+
+    public function testLoadWasmIdForExternalRefRejectsNonBytesValue(): void
+    {
+        $server = $this->createMockedSorobanServer([
+            $this->ledgerEntryResponse($this->executableTagEntryData(
+                self::TEST_OWNER_CONTRACT_ID_HEX, self::TEST_EXECUTABLE_TAG,
+                XdrSCVal::forSymbol('not-a-hash'))),
+        ]);
+        $ref = XdrContractExecutable::forExternalRef(
+            Address::fromContractId(self::TEST_OWNER_CONTRACT_ID_HEX)->toXdr(),
+            self::TEST_EXECUTABLE_TAG,
+        )->externalRef;
+        $this->assertNotNull($ref);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The executable tag entry on contract '
+            . StrKey::encodeContractIdHex(self::TEST_OWNER_CONTRACT_ID_HEX)
+            . ' does not hold a 32-byte wasm hash');
+        $server->loadWasmIdForExternalRef($ref);
+    }
+
+    public function testLoadWasmIdForExternalRefRejectsWrongLengthBytes(): void
+    {
+        $server = $this->createMockedSorobanServer([
+            $this->ledgerEntryResponse($this->executableTagEntryData(
+                self::TEST_OWNER_CONTRACT_ID_HEX, self::TEST_EXECUTABLE_TAG,
+                XdrSCVal::forBytes(hex2bin('e3b0c44298fc1c149afbf4c8996fb924')))),
+        ]);
+        $ref = XdrContractExecutable::forExternalRef(
+            Address::fromContractId(self::TEST_OWNER_CONTRACT_ID_HEX)->toXdr(),
+            self::TEST_EXECUTABLE_TAG,
+        )->externalRef;
+        $this->assertNotNull($ref);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('does not hold a 32-byte wasm hash');
+        $server->loadWasmIdForExternalRef($ref);
+    }
+
+    public function testLoadWasmIdForExternalRefRejectsNonContractDataEntry(): void
+    {
+        $server = $this->createMockedSorobanServer([
+            $this->ledgerEntryResponse($this->contractCodeEntryData(self::TEST_WASM_ID, 'x')),
+        ]);
+        $ref = XdrContractExecutable::forExternalRef(
+            Address::fromContractId(self::TEST_OWNER_CONTRACT_ID_HEX)->toXdr(),
+            self::TEST_EXECUTABLE_TAG,
+        )->externalRef;
+        $this->assertNotNull($ref);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The executable tag entry on contract '
+            . StrKey::encodeContractIdHex(self::TEST_OWNER_CONTRACT_ID_HEX)
+            . ' is not a contract data ledger entry');
+        $server->loadWasmIdForExternalRef($ref);
+    }
+
+    public function testLoadWasmIdForExternalRefRejectsNonContractOwner(): void
+    {
+        $requestHistory = [];
+        $server = $this->createMockedSorobanServer([], $requestHistory);
+        $ref = XdrContractExecutable::forExternalRef(
+            Address::fromAccountId(self::TEST_ACCOUNT_ID)->toXdr(),
+            self::TEST_EXECUTABLE_TAG,
+        )->externalRef;
+        $this->assertNotNull($ref);
+
+        $caught = null;
+        try {
+            $server->loadWasmIdForExternalRef($ref);
+        } catch (InvalidArgumentException $e) {
+            $caught = $e;
+        }
+
+        $this->assertNotNull($caught);
+        $this->assertSame('External reference owner ' . self::TEST_ACCOUNT_ID
+            . ' is not a contract address; only a contract can hold the executable tag entry',
+            $caught->getMessage());
+        $this->assertCount(0, $requestHistory);
+    }
+
+    public function testLoadWasmIdForExternalRefBinaryTag(): void
+    {
+        $binaryTag = "\x00\x01\x02\xff\xfe\x80token";
+        $requestHistory = [];
+        $server = $this->createMockedSorobanServer([
+            $this->ledgerEntryResponse($this->executableTagEntryData(
+                self::TEST_OWNER_CONTRACT_ID_HEX, $binaryTag,
+                XdrSCVal::forBytes(hex2bin(self::TEST_WASM_ID)))),
+        ], $requestHistory);
+        $ref = XdrContractExecutable::forExternalRef(
+            Address::fromContractId(self::TEST_OWNER_CONTRACT_ID_HEX)->toXdr(),
+            $binaryTag,
+        )->externalRef;
+        $this->assertNotNull($ref);
+
+        $this->assertSame(self::TEST_WASM_ID, $server->loadWasmIdForExternalRef($ref));
+
+        $this->assertCount(1, $requestHistory);
+        $tagKey = $this->requestedLedgerKey($requestHistory, 0);
+        $this->assertNotNull($tagKey->contractData);
+        $this->assertSame($binaryTag, $tagKey->contractData->key->executableTag);
+    }
+
+    public function testLoadContractInfoForContractIdExternalRefArm(): void
+    {
+        $server = $this->createMockedSorobanServer([
+            $this->ledgerEntryResponse($this->externalRefInstanceEntryData(
+                self::TEST_OWNER_CONTRACT_ID_HEX, self::TEST_EXECUTABLE_TAG)),
+            $this->ledgerEntryResponse($this->executableTagEntryData(
+                self::TEST_OWNER_CONTRACT_ID_HEX, self::TEST_EXECUTABLE_TAG,
+                XdrSCVal::forBytes(hex2bin(self::TEST_WASM_ID)))),
+            $this->ledgerEntryResponse($this->contractCodeEntryData(
+                self::TEST_WASM_ID, $this->specTestByteCode('hello'))),
+        ]);
+
+        $info = $server->loadContractInfoForContractId(self::TEST_CONTRACT_ID);
+
+        $this->assertNotNull($info);
+        $this->assertSame(23, $info->envMetaProtocol);
+        $this->assertCount(1, $info->funcs);
+        $this->assertSame('hello', $info->funcs[0]->name);
+    }
+
+    public function testLoadContractCodeForContractIdStellarAssetArm(): void
+    {
+        $requestHistory = [];
+        $server = $this->createMockedSorobanServer([
+            $this->ledgerEntryResponse($this->instanceEntryData(XdrContractExecutable::forToken())),
+        ], $requestHistory);
+
+        $this->assertNull($server->loadContractCodeForContractId(self::TEST_CONTRACT_ID));
+        $this->assertCount(1, $requestHistory);
     }
 }


### PR DESCRIPTION
A contract created from a CAP-85 external reference (Protocol 28) does not carry its own wasm hash. The instance names an owner contract and a tag, and the owner holds a persistent contract data entry under that tag whose value is the hash of an already uploaded wasm. The contract loading paths read only the wasm arm, so such a contract was reported as not found.

`loadContractCodeForContractId()` now dispatches on the executable type: the wasm arm loads as before, an external reference resolves through the owner's tag entry, and a Stellar asset instance still yields null. `loadContractInfoForContractId()` and `SorobanClient::forClientOptions()` inherit the resolution. A malformed external reference now surfaces as an `InvalidArgumentException` out of all three, where the loaders previously only returned null.

The new `SorobanServer::loadWasmIdForExternalRef()` resolves a reference directly. It returns the hex wasm id, null when the owner holds no entry under the tag, and throws `InvalidArgumentException` when the owner is not a contract address, or when the entry under the tag is not contract data holding a 32-byte wasm hash. Resolution costs one additional `getLedgerEntries` call; the owner contract is read, never invoked.

Unit tests pin the ledger keys the resolution sends, including a binary tag passed through byte for byte. The integration test skips until testnet runs protocol 28 and its fixture constants name a deployed external-ref contract.

