### PR TITLE
Parse CAP-85 external reference create contract operations and fix constructor salt decoding

### DIFF
--- a/Soneso/StellarSDK/CreateContractFromExternalRefHostFunction.php
+++ b/Soneso/StellarSDK/CreateContractFromExternalRefHostFunction.php
@@ -1,0 +1,173 @@
+<?php declare(strict_types=1);
+
+// Copyright 2026 The Stellar PHP SDK Authors. All rights reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+
+namespace Soneso\StellarSDK;
+
+use Exception;
+use Soneso\StellarSDK\Soroban\Address;
+use Soneso\StellarSDK\Xdr\XdrContractIDPreimageType;
+use Soneso\StellarSDK\Xdr\XdrHostFunction;
+use Soneso\StellarSDK\Xdr\XdrHostFunctionType;
+use Soneso\StellarSDK\Xdr\XdrContractExecutableType;
+
+/**
+ * Represents a Soroban host function for creating contracts from a CAP-85 external
+ * executable reference
+ *
+ * From Protocol 28 on, a contract can be created without naming a wasm hash directly.
+ * The executable instead names an owner contract and a tag; the owner holds a
+ * persistent contract data entry under that tag whose value is the 32-byte hash of an
+ * already uploaded wasm, and the created instance runs that code.
+ *
+ * Usage:
+ * <code>
+ * $hostFunction = new CreateContractFromExternalRefHostFunction(
+ *     Address::fromAccountId("GABC..."),   // Deployer address
+ *     Address::fromContractId($ownerId),   // Contract holding the executable tag entry
+ *     "token-v1",                          // Tag of the entry on the owner
+ *     $salt                                // Optional salt
+ * );
+ * </code>
+ *
+ * @package Soneso\StellarSDK
+ * @see HostFunction Base class for all host functions
+ * @see CreateContractFromExternalRefWithConstructorHostFunction For contracts with constructor arguments
+ * @see CreateContractHostFunction For creating contracts from a wasm hash
+ * @see https://developers.stellar.org Stellar developer docs
+ * @since 1.13.0
+ */
+class CreateContractFromExternalRefHostFunction extends HostFunction
+{
+    /**
+     * @var Address $address The deployer address
+     */
+    public Address $address;
+
+    /**
+     * @var Address $executableOwner The contract holding the executable tag entry the instance runs
+     */
+    public Address $executableOwner;
+
+    /**
+     * @var string $tag The tag the owner holds the executable entry under
+     */
+    public string $tag;
+
+    /**
+     * @var string $salt The salt value for contract address generation
+     */
+    public string $salt;
+
+
+    /**
+     * Constructs a new CreateContractFromExternalRefHostFunction
+     *
+     * @param Address $address The deployer address
+     * @param Address $executableOwner The contract holding the executable tag entry
+     * @param string $tag The tag of the executable entry on the owner; matched byte for byte
+     * @param string|null $salt Optional salt (32 random bytes generated if not provided)
+     * @throws Exception If random bytes generation fails
+     */
+    public function __construct(Address $address, Address $executableOwner, string $tag, ?string $salt = null)
+    {
+        $this->address = $address;
+        $this->executableOwner = $executableOwner;
+        $this->tag = $tag;
+        $this->salt = $salt !== null ? $salt : random_bytes(32);
+        parent::__construct();
+    }
+
+    public function toXdr() : XdrHostFunction {
+        return XdrHostFunction::forCreatingContractWithExternalRef($this->address->toXdr(),
+            $this->executableOwner->toXdr(), $this->tag, $this->salt);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public static function fromXdr(XdrHostFunction $xdr) : CreateContractFromExternalRefHostFunction {
+        $type = $xdr->type;
+        if ($type->value !== XdrHostFunctionType::HOST_FUNCTION_TYPE_CREATE_CONTRACT || $xdr->createContract === null
+            || $xdr->createContract->contractIDPreimage->type->value !== XdrContractIDPreimageType::CONTRACT_ID_PREIMAGE_FROM_ADDRESS
+            || $xdr->createContract->executable->type->value !== XdrContractExecutableType::CONTRACT_EXECUTABLE_EXTERNAL_REF) {
+            throw new Exception("Invalid argument");
+        }
+        $ref = $xdr->createContract->executable->externalRef;
+        $xdrAddress = $xdr->createContract->contractIDPreimage->address;
+
+        if ($ref === null || $xdrAddress === null) {
+            throw new Exception("invalid argument");
+        }
+        return new CreateContractFromExternalRefHostFunction(Address::fromXdr($xdrAddress),
+            Address::fromXdr($ref->executableOwner), $ref->tag, $xdr->createContract->contractIDPreimage->salt);
+    }
+
+    /**
+     * @return Address
+     */
+    public function getAddress(): Address
+    {
+        return $this->address;
+    }
+
+    /**
+     * @param Address $address
+     */
+    public function setAddress(Address $address): void
+    {
+        $this->address = $address;
+    }
+
+    /**
+     * @return Address
+     */
+    public function getExecutableOwner(): Address
+    {
+        return $this->executableOwner;
+    }
+
+    /**
+     * @param Address $executableOwner
+     */
+    public function setExecutableOwner(Address $executableOwner): void
+    {
+        $this->executableOwner = $executableOwner;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTag(): string
+    {
+        return $this->tag;
+    }
+
+    /**
+     * @param string $tag
+     */
+    public function setTag(string $tag): void
+    {
+        $this->tag = $tag;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSalt(): string
+    {
+        return $this->salt;
+    }
+
+    /**
+     * @param string $salt
+     */
+    public function setSalt(string $salt): void
+    {
+        $this->salt = $salt;
+    }
+
+}

--- a/Soneso/StellarSDK/CreateContractFromExternalRefWithConstructorHostFunction.php
+++ b/Soneso/StellarSDK/CreateContractFromExternalRefWithConstructorHostFunction.php
@@ -1,0 +1,201 @@
+<?php declare(strict_types=1);
+
+// Copyright 2026 The Stellar PHP SDK Authors. All rights reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+
+namespace Soneso\StellarSDK;
+
+use Exception;
+use Soneso\StellarSDK\Soroban\Address;
+use Soneso\StellarSDK\Xdr\XdrContractIDPreimageType;
+use Soneso\StellarSDK\Xdr\XdrHostFunction;
+use Soneso\StellarSDK\Xdr\XdrHostFunctionType;
+use Soneso\StellarSDK\Xdr\XdrContractExecutableType;
+use Soneso\StellarSDK\Xdr\XdrSCVal;
+
+/**
+ * Represents a Soroban host function for creating contracts from a CAP-85 external
+ * executable reference, passing constructor arguments
+ *
+ * Combines CreateContractFromExternalRefHostFunction with constructor initialization:
+ * the executable names an owner contract and a tag whose persistent entry holds the
+ * wasm hash, and the constructor arguments are passed to the created instance during
+ * deployment.
+ *
+ * Usage:
+ * <code>
+ * $args = [XdrSCVal::forSymbol("admin"), XdrSCVal::forAddress($adminAddress)];
+ *
+ * $hostFunction = new CreateContractFromExternalRefWithConstructorHostFunction(
+ *     Address::fromAccountId("GABC..."),   // Deployer address
+ *     Address::fromContractId($ownerId),   // Contract holding the executable tag entry
+ *     "token-v1",                          // Tag of the entry on the owner
+ *     $args,                               // Constructor arguments
+ *     $salt                                // Optional salt
+ * );
+ * </code>
+ *
+ * @package Soneso\StellarSDK
+ * @see HostFunction Base class for all host functions
+ * @see CreateContractFromExternalRefHostFunction For contracts without constructor arguments
+ * @see CreateContractWithConstructorHostFunction For the wasm hash form
+ * @see https://developers.stellar.org Stellar developer docs
+ * @since 1.13.0
+ */
+class CreateContractFromExternalRefWithConstructorHostFunction extends HostFunction
+{
+    /**
+     * @var Address $address The deployer address
+     */
+    public Address $address;
+
+    /**
+     * @var Address $executableOwner The contract holding the executable tag entry the instance runs
+     */
+    public Address $executableOwner;
+
+    /**
+     * @var string $tag The tag the owner holds the executable entry under
+     */
+    public string $tag;
+
+    /**
+     * @var array<XdrSCVal> $constructorArgs The constructor arguments
+     */
+    public array $constructorArgs;
+
+    /**
+     * @var string $salt The salt value for contract address generation
+     */
+    public string $salt;
+
+
+    /**
+     * Constructs a new CreateContractFromExternalRefWithConstructorHostFunction
+     *
+     * @param Address $address The deployer address
+     * @param Address $executableOwner The contract holding the executable tag entry
+     * @param string $tag The tag of the executable entry on the owner; matched byte for byte
+     * @param array<XdrSCVal> $constructorArgs The constructor arguments
+     * @param string|null $salt Optional salt (32 random bytes generated if not provided)
+     * @throws Exception If random bytes generation fails
+     */
+    public function __construct(Address $address, Address $executableOwner, string $tag, array $constructorArgs, ?string $salt = null)
+    {
+        $this->address = $address;
+        $this->executableOwner = $executableOwner;
+        $this->tag = $tag;
+        $this->constructorArgs = $constructorArgs;
+        $this->salt = $salt !== null ? $salt : random_bytes(32);
+        parent::__construct();
+    }
+
+    public function toXdr() : XdrHostFunction {
+        return XdrHostFunction::forCreatingContractV2WithExternalRef($this->address->toXdr(),
+            $this->executableOwner->toXdr(), $this->tag, $this->salt, $this->constructorArgs);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public static function fromXdr(XdrHostFunction $xdr) : CreateContractFromExternalRefWithConstructorHostFunction {
+        $type = $xdr->type;
+        if ($type->value !== XdrHostFunctionType::HOST_FUNCTION_TYPE_CREATE_CONTRACT_V2 || $xdr->createContractV2 === null
+            || $xdr->createContractV2->contractIDPreimage->type->value !== XdrContractIDPreimageType::CONTRACT_ID_PREIMAGE_FROM_ADDRESS
+            || $xdr->createContractV2->executable->type->value !== XdrContractExecutableType::CONTRACT_EXECUTABLE_EXTERNAL_REF) {
+            throw new Exception("Invalid argument");
+        }
+        $ref = $xdr->createContractV2->executable->externalRef;
+        $xdrAddress = $xdr->createContractV2->contractIDPreimage->address;
+
+        if ($ref === null || $xdrAddress === null) {
+            throw new Exception("invalid argument");
+        }
+        return new CreateContractFromExternalRefWithConstructorHostFunction(Address::fromXdr($xdrAddress),
+            Address::fromXdr($ref->executableOwner), $ref->tag, $xdr->createContractV2->constructorArgs,
+            $xdr->createContractV2->contractIDPreimage->salt);
+    }
+
+    /**
+     * @return Address
+     */
+    public function getAddress(): Address
+    {
+        return $this->address;
+    }
+
+    /**
+     * @param Address $address
+     */
+    public function setAddress(Address $address): void
+    {
+        $this->address = $address;
+    }
+
+    /**
+     * @return Address
+     */
+    public function getExecutableOwner(): Address
+    {
+        return $this->executableOwner;
+    }
+
+    /**
+     * @param Address $executableOwner
+     */
+    public function setExecutableOwner(Address $executableOwner): void
+    {
+        $this->executableOwner = $executableOwner;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTag(): string
+    {
+        return $this->tag;
+    }
+
+    /**
+     * @param string $tag
+     */
+    public function setTag(string $tag): void
+    {
+        $this->tag = $tag;
+    }
+
+    /**
+     * @return array<XdrSCVal>
+     */
+    public function getConstructorArgs(): array
+    {
+        return $this->constructorArgs;
+    }
+
+    /**
+     * @param array<XdrSCVal> $constructorArgs
+     */
+    public function setConstructorArgs(array $constructorArgs): void
+    {
+        $this->constructorArgs = $constructorArgs;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSalt(): string
+    {
+        return $this->salt;
+    }
+
+    /**
+     * @param string $salt
+     */
+    public function setSalt(string $salt): void
+    {
+        $this->salt = $salt;
+    }
+
+}

--- a/Soneso/StellarSDK/CreateContractWithConstructorHostFunction.php
+++ b/Soneso/StellarSDK/CreateContractWithConstructorHostFunction.php
@@ -114,7 +114,7 @@ class CreateContractWithConstructorHostFunction extends HostFunction
             throw new Exception("invalid argument");
         }
         return new CreateContractWithConstructorHostFunction(Address::fromXdr($xdrAddress), $wasmId,
-            $xdr->createContractV2->constructorArgs, $xdr->createContract->contractIDPreimage->salt);
+            $xdr->createContractV2->constructorArgs, $xdr->createContractV2->contractIDPreimage->salt);
     }
 
     /**

--- a/Soneso/StellarSDK/HostFunction.php
+++ b/Soneso/StellarSDK/HostFunction.php
@@ -19,6 +19,8 @@ use Soneso\StellarSDK\Xdr\XdrHostFunction;
  * - InvokeContractHostFunction: Call smart contract functions
  * - CreateContractHostFunction: Deploy contracts from WASM hash
  * - CreateContractWithConstructorHostFunction: Deploy contracts with constructor arguments
+ * - CreateContractFromExternalRefHostFunction: Deploy contracts from a CAP-85 external reference
+ * - CreateContractFromExternalRefWithConstructorHostFunction: Deploy contracts from a CAP-85 external reference with constructor arguments
  * - UploadContractWasmHostFunction: Upload contract WASM code
  * - DeploySACWithAssetHostFunction: Deploy Stellar Asset Contracts for assets
  *

--- a/Soneso/StellarSDK/InvokeHostFunctionOperation.php
+++ b/Soneso/StellarSDK/InvokeHostFunctionOperation.php
@@ -76,6 +76,8 @@ class InvokeHostFunctionOperation extends AbstractOperation
                 if ($contractIdPreimageTypeVal == XdrContractIDPreimageType::CONTRACT_ID_PREIMAGE_FROM_ADDRESS) {
                     if ($executableTypeValue == XdrContractExecutableType::CONTRACT_EXECUTABLE_WASM) {
                         return new InvokeHostFunctionOperation(CreateContractHostFunction::fromXdr($xdrFunction), $auth);
+                    } else if ($executableTypeValue == XdrContractExecutableType::CONTRACT_EXECUTABLE_EXTERNAL_REF) {
+                        return new InvokeHostFunctionOperation(CreateContractFromExternalRefHostFunction::fromXdr($xdrFunction), $auth);
                     }
                 } else if ($contractIdPreimageTypeVal == XdrContractIDPreimageType::CONTRACT_ID_PREIMAGE_FROM_ASSET) {
                     return new InvokeHostFunctionOperation(DeploySACWithAssetHostFunction::fromXdr($xdrFunction), $auth);
@@ -91,6 +93,8 @@ class InvokeHostFunctionOperation extends AbstractOperation
                 if ($contractIdPreimageTypeVal == XdrContractIDPreimageType::CONTRACT_ID_PREIMAGE_FROM_ADDRESS) {
                     if ($executableTypeValue == XdrContractExecutableType::CONTRACT_EXECUTABLE_WASM) {
                         return new InvokeHostFunctionOperation(CreateContractWithConstructorHostFunction::fromXdr($xdrFunction), $auth);
+                    } else if ($executableTypeValue == XdrContractExecutableType::CONTRACT_EXECUTABLE_EXTERNAL_REF) {
+                        return new InvokeHostFunctionOperation(CreateContractFromExternalRefWithConstructorHostFunction::fromXdr($xdrFunction), $auth);
                     }
                 } else if ($contractIdPreimageTypeVal == XdrContractIDPreimageType::CONTRACT_ID_PREIMAGE_FROM_ASSET) {
                     return new InvokeHostFunctionOperation(DeploySACWithAssetHostFunction::fromXdr($xdrFunction), $auth);

--- a/Soneso/StellarSDK/Xdr/XdrHostFunction.php
+++ b/Soneso/StellarSDK/Xdr/XdrHostFunction.php
@@ -88,6 +88,48 @@ class XdrHostFunction extends XdrHostFunctionBase
         return $result;
     }
 
+    /**
+     * Builds a create contract host function whose executable is a CAP-85 external
+     * reference: the instance runs the wasm named by the owner contract's persistent
+     * entry under the given tag.
+     *
+     * @param XdrSCAddress $address the deployer address
+     * @param XdrSCAddress $executableOwner the contract holding the executable tag entry
+     * @param string $tag the tag of the executable entry on the owner
+     * @param string $salt 32 byte salt for contract id generation
+     * @return XdrHostFunction
+     */
+    public static function forCreatingContractWithExternalRef(XdrSCAddress $address, XdrSCAddress $executableOwner, string $tag, string $salt) :  XdrHostFunction {
+        $result = new XdrHostFunction(XdrHostFunctionType::CREATE_CONTRACT());
+        $cId = new XdrContractIDPreimage(XdrContractIDPreimageType::CONTRACT_ID_PREIMAGE_FROM_ADDRESS());
+        $cId->address = $address;
+        $cId->salt = $salt;
+        $cCode = XdrContractExecutable::forExternalRef($executableOwner, $tag);
+        $result->createContract = new XdrCreateContractArgs($cId, $cCode);
+        return $result;
+    }
+
+    /**
+     * Builds a create contract v2 host function whose executable is a CAP-85 external
+     * reference, passing constructor arguments to the created instance.
+     *
+     * @param XdrSCAddress $address the deployer address
+     * @param XdrSCAddress $executableOwner the contract holding the executable tag entry
+     * @param string $tag the tag of the executable entry on the owner
+     * @param string $salt 32 byte salt for contract id generation
+     * @param array<XdrSCVal> $constructorArgs arguments passed to the contract constructor
+     * @return XdrHostFunction
+     */
+    public static function forCreatingContractV2WithExternalRef(XdrSCAddress $address, XdrSCAddress $executableOwner, string $tag, string $salt, array $constructorArgs) :  XdrHostFunction {
+        $result = new XdrHostFunction(XdrHostFunctionType::CREATE_CONTRACT_V2());
+        $cId = new XdrContractIDPreimage(XdrContractIDPreimageType::CONTRACT_ID_PREIMAGE_FROM_ADDRESS());
+        $cId->address = $address;
+        $cId->salt = $salt;
+        $cCode = XdrContractExecutable::forExternalRef($executableOwner, $tag);
+        $result->createContractV2 = new XdrCreateContractArgsV2($cId, $cCode, $constructorArgs);
+        return $result;
+    }
+
     public static function forDeploySACWithAsset(XdrAsset $asset) :  XdrHostFunction {
         $result = new XdrHostFunction(XdrHostFunctionType::CREATE_CONTRACT());
         $cId = new XdrContractIDPreimage(XdrContractIDPreimageType::CONTRACT_ID_PREIMAGE_FROM_ASSET());

--- a/Soneso/StellarSDKTests/Unit/Soroban/HostFunctionTest.php
+++ b/Soneso/StellarSDKTests/Unit/Soroban/HostFunctionTest.php
@@ -9,14 +9,19 @@ namespace Soneso\StellarSDKTests\Unit\Soroban;
 use PHPUnit\Framework\TestCase;
 use Soneso\StellarSDK\Asset;
 use Soneso\StellarSDK\AssetTypeNative;
+use Soneso\StellarSDK\CreateContractFromExternalRefHostFunction;
+use Soneso\StellarSDK\CreateContractFromExternalRefWithConstructorHostFunction;
 use Soneso\StellarSDK\CreateContractHostFunction;
 use Soneso\StellarSDK\CreateContractWithConstructorHostFunction;
 use Soneso\StellarSDK\DeploySACWithAssetHostFunction;
 use Soneso\StellarSDK\InvokeContractHostFunction;
 use Soneso\StellarSDK\InvokeHostFunctionOperation;
 use Soneso\StellarSDK\Soroban\Address;
+use Soneso\StellarSDK\Xdr\XdrBuffer;
 use Soneso\StellarSDK\Xdr\XdrContractExecutable;
 use Soneso\StellarSDK\Xdr\XdrContractIDPreimage;
+use Soneso\StellarSDK\Xdr\XdrContractIDPreimageType;
+use Soneso\StellarSDK\Xdr\XdrCreateContractArgs;
 use Soneso\StellarSDK\Xdr\XdrCreateContractArgsV2;
 use Soneso\StellarSDK\Xdr\XdrHostFunction;
 use Soneso\StellarSDK\Xdr\XdrInvokeHostFunctionOp;
@@ -33,8 +38,9 @@ use Exception;
 class HostFunctionTest extends TestCase
 {
     private const TEST_ACCOUNT_ID = 'GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H';
-    private const TEST_ISSUER_ID = 'GDQP2KPQGKIHYJGXNUIYOMHARUARCA7DJT5FO2FFOOUJ3DANUBER3WPR';
+    private const TEST_ISSUER_ID = 'GABAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEJXA';
     private const TEST_CONTRACT_ID = 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC';
+    private const TEST_OWNER_ID_HEX = 'cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd';
 
     // CreateContractHostFunction Tests
 
@@ -465,5 +471,263 @@ class HostFunctionTest extends TestCase
         /** @var DeploySACWithAssetHostFunction $hostFunction */
         $hostFunction = $operation->getFunction();
         $this->assertInstanceOf(AssetTypeNative::class, $hostFunction->getAsset());
+    }
+
+    // CreateContractFromExternalRefHostFunction Tests
+
+    public function testCreateContractFromExternalRefToXdrRoundTrip(): void
+    {
+        $address = Address::fromAccountId(self::TEST_ACCOUNT_ID);
+        $owner = Address::fromContractId(self::TEST_OWNER_ID_HEX);
+        $salt = str_repeat("\x11", 32);
+
+        $original = new CreateContractFromExternalRefHostFunction($address, $owner, "token-v1", $salt);
+        $xdr = $original->toXdr();
+        $decodedXdr = XdrHostFunction::decode(new XdrBuffer($xdr->encode()));
+        $decoded = CreateContractFromExternalRefHostFunction::fromXdr($decodedXdr);
+
+        $this->assertEquals(self::TEST_ACCOUNT_ID, $decoded->getAddress()->accountId);
+        $this->assertEquals(self::TEST_OWNER_ID_HEX, $decoded->getExecutableOwner()->contractId);
+        $this->assertEquals("token-v1", $decoded->getTag());
+        $this->assertSame($salt, $decoded->getSalt());
+        $this->assertEquals(base64_encode($xdr->encode()), base64_encode($decoded->toXdr()->encode()));
+    }
+
+    public function testCreateContractFromExternalRefWithConstructorToXdrRoundTrip(): void
+    {
+        $address = Address::fromAccountId(self::TEST_ACCOUNT_ID);
+        $owner = Address::fromContractId(self::TEST_OWNER_ID_HEX);
+        $salt = str_repeat("\x11", 32);
+        $args = [XdrSCVal::forU32(7)];
+
+        $original = new CreateContractFromExternalRefWithConstructorHostFunction($address, $owner, "token-v1", $args, $salt);
+        $xdr = $original->toXdr();
+        $decodedXdr = XdrHostFunction::decode(new XdrBuffer($xdr->encode()));
+        $decoded = CreateContractFromExternalRefWithConstructorHostFunction::fromXdr($decodedXdr);
+
+        $this->assertEquals(self::TEST_ACCOUNT_ID, $decoded->getAddress()->accountId);
+        $this->assertEquals(self::TEST_OWNER_ID_HEX, $decoded->getExecutableOwner()->contractId);
+        $this->assertEquals("token-v1", $decoded->getTag());
+        $this->assertSame($salt, $decoded->getSalt());
+        $this->assertCount(1, $decoded->getConstructorArgs());
+        $this->assertEquals(7, $decoded->getConstructorArgs()[0]->u32);
+        $this->assertEquals(base64_encode($xdr->encode()), base64_encode($decoded->toXdr()->encode()));
+    }
+
+    public function testCreateContractFromExternalRefWithoutSaltGeneratesSalt(): void
+    {
+        $address = Address::fromAccountId(self::TEST_ACCOUNT_ID);
+        $owner = Address::fromContractId(self::TEST_OWNER_ID_HEX);
+
+        $plain = new CreateContractFromExternalRefHostFunction($address, $owner, "token-v1");
+        $this->assertEquals(32, strlen($plain->getSalt()));
+        $this->assertSame($plain->getSalt(), $plain->toXdr()->createContract->contractIDPreimage->salt);
+
+        $withConstructor = new CreateContractFromExternalRefWithConstructorHostFunction($address, $owner, "token-v1", []);
+        $this->assertEquals(32, strlen($withConstructor->getSalt()));
+        $this->assertSame($withConstructor->getSalt(), $withConstructor->toXdr()->createContractV2->contractIDPreimage->salt);
+    }
+
+    public function testCreateContractFromExternalRefSettersReplaceEveryField(): void
+    {
+        $salt1 = str_repeat("\x11", 32);
+        $salt2 = str_repeat("\x22", 32);
+        $ownerIdHex2 = str_repeat("ef", 32);
+
+        $hostFunction = new CreateContractFromExternalRefHostFunction(
+            Address::fromAccountId(self::TEST_ACCOUNT_ID),
+            Address::fromContractId(self::TEST_OWNER_ID_HEX),
+            "token-v1",
+            $salt1
+        );
+        $hostFunction->setAddress(Address::fromAccountId(self::TEST_ISSUER_ID));
+        $hostFunction->setExecutableOwner(Address::fromContractId($ownerIdHex2));
+        $hostFunction->setTag("token-v2");
+        $hostFunction->setSalt($salt2);
+
+        $expected = new CreateContractFromExternalRefHostFunction(
+            Address::fromAccountId(self::TEST_ISSUER_ID),
+            Address::fromContractId($ownerIdHex2),
+            "token-v2",
+            $salt2
+        );
+        $this->assertEquals(self::TEST_ISSUER_ID, $hostFunction->getAddress()->accountId);
+        $this->assertEquals(base64_encode($expected->toXdr()->encode()), base64_encode($hostFunction->toXdr()->encode()));
+    }
+
+    public function testCreateContractFromExternalRefWithConstructorSettersReplaceEveryField(): void
+    {
+        $salt1 = str_repeat("\x11", 32);
+        $salt2 = str_repeat("\x22", 32);
+        $ownerIdHex2 = str_repeat("ef", 32);
+
+        $hostFunction = new CreateContractFromExternalRefWithConstructorHostFunction(
+            Address::fromAccountId(self::TEST_ACCOUNT_ID),
+            Address::fromContractId(self::TEST_OWNER_ID_HEX),
+            "token-v1",
+            [XdrSCVal::forU32(7)],
+            $salt1
+        );
+        $hostFunction->setAddress(Address::fromAccountId(self::TEST_ISSUER_ID));
+        $hostFunction->setExecutableOwner(Address::fromContractId($ownerIdHex2));
+        $hostFunction->setTag("token-v2");
+        $hostFunction->setConstructorArgs([XdrSCVal::forU32(9)]);
+        $hostFunction->setSalt($salt2);
+
+        $expected = new CreateContractFromExternalRefWithConstructorHostFunction(
+            Address::fromAccountId(self::TEST_ISSUER_ID),
+            Address::fromContractId($ownerIdHex2),
+            "token-v2",
+            [XdrSCVal::forU32(9)],
+            $salt2
+        );
+        $this->assertEquals(self::TEST_ISSUER_ID, $hostFunction->getAddress()->accountId);
+        $this->assertEquals(base64_encode($expected->toXdr()->encode()), base64_encode($hostFunction->toXdr()->encode()));
+    }
+
+    public function testExternalRefBinaryTagSurvivesRoundTrip(): void
+    {
+        $tag = "\x80\xff\x00tag\x01";
+        $address = Address::fromAccountId(self::TEST_ACCOUNT_ID);
+        $owner = Address::fromContractId(self::TEST_OWNER_ID_HEX);
+        $salt = str_repeat("\x11", 32);
+
+        $original = new CreateContractFromExternalRefHostFunction($address, $owner, $tag, $salt);
+        $decodedXdr = XdrHostFunction::decode(new XdrBuffer($original->toXdr()->encode()));
+        $decoded = CreateContractFromExternalRefHostFunction::fromXdr($decodedXdr);
+
+        $this->assertSame($tag, $decoded->getTag());
+        $this->assertEquals(base64_encode($original->toXdr()->encode()), base64_encode($decoded->toXdr()->encode()));
+    }
+
+    public function testFromXdrOperationParsesExternalRefCreate(): void
+    {
+        $hostFunction = new CreateContractFromExternalRefHostFunction(
+            Address::fromAccountId(self::TEST_ACCOUNT_ID),
+            Address::fromContractId(self::TEST_OWNER_ID_HEX),
+            "token-v1",
+            str_repeat("\x11", 32)
+        );
+        $xdrOp = new XdrInvokeHostFunctionOp($hostFunction->toXdr(), []);
+
+        $operation = InvokeHostFunctionOperation::fromXdrOperation($xdrOp);
+
+        $this->assertInstanceOf(CreateContractFromExternalRefHostFunction::class, $operation->getFunction());
+        /** @var CreateContractFromExternalRefHostFunction $parsed */
+        $parsed = $operation->getFunction();
+        $this->assertEquals(self::TEST_OWNER_ID_HEX, $parsed->getExecutableOwner()->contractId);
+        $this->assertEquals("token-v1", $parsed->getTag());
+        $this->assertEquals(base64_encode($hostFunction->toXdr()->encode()), base64_encode($parsed->toXdr()->encode()));
+    }
+
+    public function testFromXdrOperationParsesExternalRefCreateWithConstructor(): void
+    {
+        $hostFunction = new CreateContractFromExternalRefWithConstructorHostFunction(
+            Address::fromAccountId(self::TEST_ACCOUNT_ID),
+            Address::fromContractId(self::TEST_OWNER_ID_HEX),
+            "token-v1",
+            [XdrSCVal::forU32(7)],
+            str_repeat("\x11", 32)
+        );
+        $xdrOp = new XdrInvokeHostFunctionOp($hostFunction->toXdr(), []);
+
+        $operation = InvokeHostFunctionOperation::fromXdrOperation($xdrOp);
+
+        $this->assertInstanceOf(CreateContractFromExternalRefWithConstructorHostFunction::class, $operation->getFunction());
+        /** @var CreateContractFromExternalRefWithConstructorHostFunction $parsed */
+        $parsed = $operation->getFunction();
+        $this->assertEquals(self::TEST_OWNER_ID_HEX, $parsed->getExecutableOwner()->contractId);
+        $this->assertEquals("token-v1", $parsed->getTag());
+        $this->assertCount(1, $parsed->getConstructorArgs());
+        $this->assertEquals(base64_encode($hostFunction->toXdr()->encode()), base64_encode($parsed->toXdr()->encode()));
+    }
+
+    public function testFromXdrOperationRejectsInvalidExecutableCombinations(): void
+    {
+        $ownerXdr = Address::fromContractId(self::TEST_OWNER_ID_HEX)->toXdr();
+        $assetPreimage = XdrContractIDPreimage::forAsset((new AssetTypeNative())->toXdr());
+        $addressPreimage = new XdrContractIDPreimage(XdrContractIDPreimageType::CONTRACT_ID_PREIMAGE_FROM_ADDRESS());
+        $addressPreimage->address = Address::fromAccountId(self::TEST_ACCOUNT_ID)->toXdr();
+        $addressPreimage->salt = str_repeat("\x11", 32);
+        $externalRefExecutable = XdrContractExecutable::forExternalRef($ownerXdr, "token-v1");
+        $tokenExecutable = XdrContractExecutable::forToken();
+
+        $cases = [
+            'CREATE_CONTRACT asset preimage with external ref executable' =>
+                XdrHostFunction::forCreatingContractWithArgs(new XdrCreateContractArgs($assetPreimage, $externalRefExecutable)),
+            'CREATE_CONTRACT_V2 asset preimage with external ref executable' =>
+                XdrHostFunction::forCreatingContractV2WithArgs(new XdrCreateContractArgsV2($assetPreimage, $externalRefExecutable, [])),
+            'CREATE_CONTRACT address preimage with stellar asset executable' =>
+                XdrHostFunction::forCreatingContractWithArgs(new XdrCreateContractArgs($addressPreimage, $tokenExecutable)),
+            'CREATE_CONTRACT_V2 address preimage with stellar asset executable' =>
+                XdrHostFunction::forCreatingContractV2WithArgs(new XdrCreateContractArgsV2($addressPreimage, $tokenExecutable, [])),
+        ];
+
+        foreach ($cases as $label => $xdrHostFunction) {
+            $threw = false;
+            try {
+                InvokeHostFunctionOperation::fromXdrOperation(new XdrInvokeHostFunctionOp($xdrHostFunction, []));
+            } catch (Exception $e) {
+                $threw = true;
+                $this->assertStringContainsStringIgnoringCase("invalid argument", $e->getMessage(), $label);
+            }
+            $this->assertTrue($threw, "expected an exception for: " . $label);
+        }
+    }
+
+    public function testWasmCreateContractClassesRejectExternalRefXdr(): void
+    {
+        $address = Address::fromAccountId(self::TEST_ACCOUNT_ID);
+        $owner = Address::fromContractId(self::TEST_OWNER_ID_HEX);
+        $salt = str_repeat("\x11", 32);
+
+        $externalRefXdr = (new CreateContractFromExternalRefHostFunction($address, $owner, "token-v1", $salt))->toXdr();
+        $threw = false;
+        try {
+            CreateContractHostFunction::fromXdr($externalRefXdr);
+        } catch (Exception $e) {
+            $threw = true;
+            $this->assertStringContainsStringIgnoringCase("invalid argument", $e->getMessage());
+        }
+        $this->assertTrue($threw, "CreateContractHostFunction accepted an external ref executable");
+
+        $externalRefV2Xdr = (new CreateContractFromExternalRefWithConstructorHostFunction($address, $owner, "token-v1", [], $salt))->toXdr();
+        $threw = false;
+        try {
+            CreateContractWithConstructorHostFunction::fromXdr($externalRefV2Xdr);
+        } catch (Exception $e) {
+            $threw = true;
+            $this->assertStringContainsStringIgnoringCase("invalid argument", $e->getMessage());
+        }
+        $this->assertTrue($threw, "CreateContractWithConstructorHostFunction accepted an external ref executable");
+    }
+
+    public function testCreateContractFromExternalRefFromXdrWrongExecutableThrows(): void
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage("Invalid argument");
+
+        // Create contract XDR with a wasm executable instead of an external reference
+        $wasmHostFunction = new CreateContractHostFunction(
+            Address::fromAccountId(self::TEST_ACCOUNT_ID),
+            str_repeat("ab", 32)
+        );
+
+        CreateContractFromExternalRefHostFunction::fromXdr($wasmHostFunction->toXdr());
+    }
+
+    public function testCreateContractFromExternalRefWithConstructorFromXdrWrongExecutableThrows(): void
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage("Invalid argument");
+
+        // Create contract v2 XDR with a wasm executable instead of an external reference
+        $wasmHostFunction = new CreateContractWithConstructorHostFunction(
+            Address::fromAccountId(self::TEST_ACCOUNT_ID),
+            str_repeat("ab", 32),
+            []
+        );
+
+        CreateContractFromExternalRefWithConstructorHostFunction::fromXdr($wasmHostFunction->toXdr());
     }
 }

--- a/Soneso/StellarSDKTests/Unit/Soroban/HostFunctionTest.php
+++ b/Soneso/StellarSDKTests/Unit/Soroban/HostFunctionTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\TestCase;
 use Soneso\StellarSDK\Asset;
 use Soneso\StellarSDK\AssetTypeNative;
 use Soneso\StellarSDK\CreateContractHostFunction;
+use Soneso\StellarSDK\CreateContractWithConstructorHostFunction;
 use Soneso\StellarSDK\DeploySACWithAssetHostFunction;
 use Soneso\StellarSDK\InvokeContractHostFunction;
 use Soneso\StellarSDK\InvokeHostFunctionOperation;
@@ -114,6 +115,27 @@ class HostFunctionTest extends TestCase
 
         $hostFunction->setSalt($salt2);
         $this->assertEquals($salt2, $hostFunction->getSalt());
+    }
+
+    // CreateContractWithConstructorHostFunction Tests
+
+    public function testCreateContractWithConstructorToXdrRoundTrip(): void
+    {
+        $address = Address::fromAccountId(self::TEST_ACCOUNT_ID);
+        $wasmId = str_repeat("ab", 32);
+        $salt = str_repeat("\x11", 32);
+        $args = [XdrSCVal::forU32(7)];
+
+        $original = new CreateContractWithConstructorHostFunction($address, $wasmId, $args, $salt);
+        $xdr = $original->toXdr();
+        $decoded = CreateContractWithConstructorHostFunction::fromXdr($xdr);
+
+        $this->assertEquals($original->getWasmId(), $decoded->getWasmId());
+        $this->assertEquals($original->getSalt(), $decoded->getSalt());
+        $this->assertEquals($original->getAddress()->accountId, $decoded->getAddress()->accountId);
+        $this->assertCount(1, $decoded->getConstructorArgs());
+        $this->assertEquals(7, $decoded->getConstructorArgs()[0]->u32);
+        $this->assertEquals(base64_encode($xdr->encode()), base64_encode($decoded->toXdr()->encode()));
     }
 
     // DeploySACWithAssetHostFunction Tests


### PR DESCRIPTION
Two commits, one per issue.

`CreateContractWithConstructorHostFunction::fromXdr()` read the salt from the CREATE_CONTRACT arm of the host function union, which is null for a CREATE_CONTRACT_V2 host function. A property read on null yields a warning and null, so the parsed salt silently became fresh random bytes and re-encoding derived a different contract id. The salt now comes from the CREATE_CONTRACT_V2 arm; a round trip test pins the exact bytes. Fixes #116.

Deserializing a transaction envelope that creates a contract from a CAP-85 external reference (Protocol 28) threw "invalid argument": the parsing sites accepted only the wasm or Stellar asset arm. The new `CreateContractFromExternalRefHostFunction` and `CreateContractFromExternalRefWithConstructorHostFunction` build and parse such operations over the new `XdrHostFunction::forCreatingContractWithExternalRef()` and `forCreatingContractV2WithExternalRef()` factories, and `InvokeHostFunctionOperation::fromXdrOperation()` returns them for both the CREATE_CONTRACT and CREATE_CONTRACT_V2 arms. Fixes #115.

Unit tests round trip both new host functions through encoded bytes, including a binary tag passed through unchanged. They cover the operation parsing for both arms and pin the rejection of the invalid preimage and executable combinations. The `TEST_ISSUER_ID` fixture in `HostFunctionTest` carried an invalid checksum that no earlier test serialized; it is replaced with a valid account id.
