### PR TITLE
Protocol 28 preparation: ADDRESS_V2 defaults, external-ref hardening, and amount fixes

### DIFF
--- a/Soneso/StellarSDK/CreateContractFromExternalRefHostFunction.php
+++ b/Soneso/StellarSDK/CreateContractFromExternalRefHostFunction.php
@@ -8,6 +8,7 @@
 namespace Soneso\StellarSDK;
 
 use Exception;
+use InvalidArgumentException;
 use Soneso\StellarSDK\Soroban\Address;
 use Soneso\StellarSDK\Xdr\XdrContractIDPreimageType;
 use Soneso\StellarSDK\Xdr\XdrHostFunction;
@@ -22,6 +23,10 @@ use Soneso\StellarSDK\Xdr\XdrContractExecutableType;
  * The executable instead names an owner contract and a tag; the owner holds a
  * persistent contract data entry under that tag whose value is the 32-byte hash of an
  * already uploaded wasm, and the created instance runs that code.
+ *
+ * The executable owner must be a contract address — only a contract can hold the
+ * executable tag entry. The constructor, setExecutableOwner(), and toXdr() reject any
+ * other address type.
  *
  * Usage:
  * <code>
@@ -70,10 +75,12 @@ class CreateContractFromExternalRefHostFunction extends HostFunction
      * @param Address $executableOwner The contract holding the executable tag entry
      * @param string $tag The tag of the executable entry on the owner; matched byte for byte
      * @param string|null $salt Optional salt (32 random bytes generated if not provided)
+     * @throws InvalidArgumentException If the executable owner is not a contract address
      * @throws Exception If random bytes generation fails
      */
     public function __construct(Address $address, Address $executableOwner, string $tag, ?string $salt = null)
     {
+        self::assertOwnerIsContract($executableOwner);
         $this->address = $address;
         $this->executableOwner = $executableOwner;
         $this->tag = $tag;
@@ -81,13 +88,18 @@ class CreateContractFromExternalRefHostFunction extends HostFunction
         parent::__construct();
     }
 
+    /**
+     * @throws InvalidArgumentException If the executable owner is not a contract address
+     */
     public function toXdr() : XdrHostFunction {
+        self::assertOwnerIsContract($this->executableOwner);
         return XdrHostFunction::forCreatingContractWithExternalRef($this->address->toXdr(),
             $this->executableOwner->toXdr(), $this->tag, $this->salt);
     }
 
     /**
-     * @throws Exception
+     * @throws InvalidArgumentException If the executable owner in the XDR is not a contract address
+     * @throws Exception If the XDR does not carry an external-ref CREATE_CONTRACT host function
      */
     public static function fromXdr(XdrHostFunction $xdr) : CreateContractFromExternalRefHostFunction {
         $type = $xdr->type;
@@ -132,9 +144,11 @@ class CreateContractFromExternalRefHostFunction extends HostFunction
 
     /**
      * @param Address $executableOwner
+     * @throws InvalidArgumentException If the executable owner is not a contract address
      */
     public function setExecutableOwner(Address $executableOwner): void
     {
+        self::assertOwnerIsContract($executableOwner);
         $this->executableOwner = $executableOwner;
     }
 
@@ -168,6 +182,17 @@ class CreateContractFromExternalRefHostFunction extends HostFunction
     public function setSalt(string $salt): void
     {
         $this->salt = $salt;
+    }
+
+    /**
+     * @throws InvalidArgumentException If the executable owner is not a contract address
+     */
+    private static function assertOwnerIsContract(Address $executableOwner): void
+    {
+        if ($executableOwner->type !== Address::TYPE_CONTRACT) {
+            throw new InvalidArgumentException(
+                "External reference owner is not a contract address; only a contract can hold the executable tag entry");
+        }
     }
 
 }

--- a/Soneso/StellarSDK/CreateContractFromExternalRefWithConstructorHostFunction.php
+++ b/Soneso/StellarSDK/CreateContractFromExternalRefWithConstructorHostFunction.php
@@ -8,6 +8,7 @@
 namespace Soneso\StellarSDK;
 
 use Exception;
+use InvalidArgumentException;
 use Soneso\StellarSDK\Soroban\Address;
 use Soneso\StellarSDK\Xdr\XdrContractIDPreimageType;
 use Soneso\StellarSDK\Xdr\XdrHostFunction;
@@ -23,6 +24,10 @@ use Soneso\StellarSDK\Xdr\XdrSCVal;
  * the executable names an owner contract and a tag whose persistent entry holds the
  * wasm hash, and the constructor arguments are passed to the created instance during
  * deployment.
+ *
+ * The executable owner must be a contract address — only a contract can hold the
+ * executable tag entry. The constructor, setExecutableOwner(), and toXdr() reject any
+ * other address type.
  *
  * Usage:
  * <code>
@@ -80,10 +85,12 @@ class CreateContractFromExternalRefWithConstructorHostFunction extends HostFunct
      * @param string $tag The tag of the executable entry on the owner; matched byte for byte
      * @param array<XdrSCVal> $constructorArgs The constructor arguments
      * @param string|null $salt Optional salt (32 random bytes generated if not provided)
+     * @throws InvalidArgumentException If the executable owner is not a contract address
      * @throws Exception If random bytes generation fails
      */
     public function __construct(Address $address, Address $executableOwner, string $tag, array $constructorArgs, ?string $salt = null)
     {
+        self::assertOwnerIsContract($executableOwner);
         $this->address = $address;
         $this->executableOwner = $executableOwner;
         $this->tag = $tag;
@@ -92,13 +99,18 @@ class CreateContractFromExternalRefWithConstructorHostFunction extends HostFunct
         parent::__construct();
     }
 
+    /**
+     * @throws InvalidArgumentException If the executable owner is not a contract address
+     */
     public function toXdr() : XdrHostFunction {
+        self::assertOwnerIsContract($this->executableOwner);
         return XdrHostFunction::forCreatingContractV2WithExternalRef($this->address->toXdr(),
             $this->executableOwner->toXdr(), $this->tag, $this->salt, $this->constructorArgs);
     }
 
     /**
-     * @throws Exception
+     * @throws InvalidArgumentException If the executable owner in the XDR is not a contract address
+     * @throws Exception If the XDR does not carry an external-ref CREATE_CONTRACT_V2 host function
      */
     public static function fromXdr(XdrHostFunction $xdr) : CreateContractFromExternalRefWithConstructorHostFunction {
         $type = $xdr->type;
@@ -144,9 +156,11 @@ class CreateContractFromExternalRefWithConstructorHostFunction extends HostFunct
 
     /**
      * @param Address $executableOwner
+     * @throws InvalidArgumentException If the executable owner is not a contract address
      */
     public function setExecutableOwner(Address $executableOwner): void
     {
+        self::assertOwnerIsContract($executableOwner);
         $this->executableOwner = $executableOwner;
     }
 
@@ -196,6 +210,17 @@ class CreateContractFromExternalRefWithConstructorHostFunction extends HostFunct
     public function setSalt(string $salt): void
     {
         $this->salt = $salt;
+    }
+
+    /**
+     * @throws InvalidArgumentException If the executable owner is not a contract address
+     */
+    private static function assertOwnerIsContract(Address $executableOwner): void
+    {
+        if ($executableOwner->type !== Address::TYPE_CONTRACT) {
+            throw new InvalidArgumentException(
+                "External reference owner is not a contract address; only a contract can hold the executable tag entry");
+        }
     }
 
 }

--- a/Soneso/StellarSDK/SEP/Interactive/InteractiveService.php
+++ b/Soneso/StellarSDK/SEP/Interactive/InteractiveService.php
@@ -13,6 +13,7 @@ use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\HandlerStack;
 use Soneso\StellarSDK\SEP\Toml\StellarToml;
+use Soneso\StellarSDK\SEP\Shared\SepRequestAmount;
 use Soneso\StellarSDK\Util\UrlValidator;
 
 /**
@@ -97,7 +98,7 @@ class InteractiveService
          * @var array<array-key, mixed> $queryParameters
          */
         $queryParameters = ["operation" => $request->operation,
-            "asset_code" => $request->assetCode, "amount" => $request->amount];
+            "asset_code" => $request->assetCode, "amount" => SepRequestAmount::format($request->amount)];
         if ($request->type !== null) {
             $queryParameters ["type"] = $request->type;
         }
@@ -197,7 +198,7 @@ class InteractiveService
             $fields += ["source_asset" => $request->sourceAsset];
         }
         if ($request->amount !== null) {
-            $fields += ["amount" => $request->amount];
+            $fields += ["amount" => SepRequestAmount::format($request->amount)];
         }
         if ($request->quoteId !== null) {
             $fields += ["quote_id" => $request->quoteId];
@@ -295,7 +296,7 @@ class InteractiveService
             $fields += ["asset_issuer" => $request->assetIssuer];
         }
         if ($request->amount !== null) {
-            $fields += ["amount" => $request->amount];
+            $fields += ["amount" => SepRequestAmount::format($request->amount)];
         }
         if ($request->quoteId !== null) {
             $fields += ["quote_id" => $request->quoteId];

--- a/Soneso/StellarSDK/SEP/Shared/SepRequestAmount.php
+++ b/Soneso/StellarSDK/SEP/Shared/SepRequestAmount.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types=1);
+
+// Copyright 2026 The Stellar PHP SDK Authors. All rights reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+namespace Soneso\StellarSDK\SEP\Shared;
+
+/**
+ * Renders an asset amount for a SEP request field.
+ *
+ * Scoped to the classic seven decimal places, and to request fields the SDK types as a float.
+ * Not for Soroban token amounts, whose scale the token defines and which routinely carry far more
+ * than seven decimals, and not for transaction amounts, which reach operation XDR through
+ * AbstractOperation::toXdrAmount.
+ *
+ * @package Soneso\StellarSDK\SEP\Shared
+ */
+class SepRequestAmount
+{
+    /**
+     * Renders an amount as a plain decimal string suitable for a request parameter.
+     *
+     * Never uses scientific notation, which casting a float to string switches to for small and
+     * large magnitudes and which anchors do not accept. Stellar assets carry at most seven decimal
+     * places, so the fraction is rounded to seven digits, trailing zeroes in the fractional part are
+     * trimmed and the decimal point is suppressed for whole amounts.
+     *
+     * The rendering is locale independent: the %F conversion never follows LC_NUMERIC, unlike the
+     * lowercase %f that an application's setlocale() call would reach. It also formats from the
+     * float itself, so it does not lose significant digits the way casting does under the default
+     * precision setting.
+     *
+     * Three limits are worth knowing. An amount below half a stroop rounds to 0 and the sign is
+     * dropped, and a non-finite amount renders as the empty string; neither names an amount the
+     * caller can transact, and both leave the anchor to answer. From 2^29 (536870912) upward a
+     * float no longer carries seven meaningful fractional digits, because that is where one unit
+     * in the last place first exceeds a stroop, so the last digits describe the stored value
+     * rather than the amount that was written.
+     *
+     * @param float $amount The amount to render.
+     * @return string The amount as a plain decimal string.
+     */
+    public static function format(float $amount): string
+    {
+        if (!is_finite($amount)) {
+            return '';
+        }
+
+        $formatted = sprintf('%.7F', $amount);
+        $formatted = rtrim($formatted, '0');
+        $formatted = rtrim($formatted, '.');
+
+        return $formatted === '-0' ? '0' : $formatted;
+    }
+}

--- a/Soneso/StellarSDK/SEP/Shared/SepRequestAmount.php
+++ b/Soneso/StellarSDK/SEP/Shared/SepRequestAmount.php
@@ -21,22 +21,21 @@ class SepRequestAmount
     /**
      * Renders an amount as a plain decimal string suitable for a request parameter.
      *
-     * Never uses scientific notation, which casting a float to string switches to for small and
-     * large magnitudes and which anchors do not accept. Stellar assets carry at most seven decimal
-     * places, so the fraction is rounded to seven digits, trailing zeroes in the fractional part are
-     * trimmed and the decimal point is suppressed for whole amounts.
+     * The rendering starts from the shortest decimal representation that reads back to the same
+     * float and rounds it to at most seven decimal places, trimming trailing fractional zeroes
+     * and suppressing the decimal point for whole amounts. It never uses scientific notation,
+     * which anchors do not accept, and it never renders the binary expansion behind the shortest
+     * representation. A fraction that ends exactly halfway rounds away from zero.
      *
-     * The rendering is locale independent: the %F conversion never follows LC_NUMERIC, unlike the
-     * lowercase %f that an application's setlocale() call would reach. It also formats from the
-     * float itself, so it does not lose significant digits the way casting does under the default
-     * precision setting.
+     * The rendering is locale independent: every step is decimal string arithmetic on
+     * json_encode's output, which always uses ASCII digits and a period whatever LC_NUMERIC a
+     * caller's setlocale() run has applied. The serialize_precision setting is pinned to -1 for
+     * the encode and restored, so a host configuration that caps or widens it cannot change the
+     * digits.
      *
-     * Three limits are worth knowing. An amount below half a stroop rounds to 0 and the sign is
+     * Two limits are worth knowing. An amount below half a stroop rounds to 0 and the sign is
      * dropped, and a non-finite amount renders as the empty string; neither names an amount the
-     * caller can transact, and both leave the anchor to answer. From 2^29 (536870912) upward a
-     * float no longer carries seven meaningful fractional digits, because that is where one unit
-     * in the last place first exceeds a stroop, so the last digits describe the stored value
-     * rather than the amount that was written.
+     * caller can transact, and both leave the anchor to answer.
      *
      * @param float $amount The amount to render.
      * @return string The amount as a plain decimal string.
@@ -47,10 +46,80 @@ class SepRequestAmount
             return '';
         }
 
-        $formatted = sprintf('%.7F', $amount);
-        $formatted = rtrim($formatted, '0');
-        $formatted = rtrim($formatted, '.');
+        $previousPrecision = ini_set('serialize_precision', '-1');
+        $shortest = (string) json_encode($amount);
+        if ($previousPrecision !== false) {
+            ini_set('serialize_precision', $previousPrecision);
+        }
 
-        return $formatted === '-0' ? '0' : $formatted;
+        $sign = '';
+        if (str_starts_with($shortest, '-')) {
+            $sign = '-';
+            $shortest = substr($shortest, 1);
+        }
+
+        // Split the representation into its digit string and the position of the decimal
+        // point within it, folding a scientific exponent into that position.
+        $exponent = 0;
+        $ePos = stripos($shortest, 'e');
+        if ($ePos !== false) {
+            $exponent = (int) substr($shortest, $ePos + 1);
+            $shortest = substr($shortest, 0, $ePos);
+        }
+        $dotPos = strpos($shortest, '.');
+        if ($dotPos !== false) {
+            $pointPosition = $dotPos;
+            $shortest = str_replace('.', '', $shortest);
+        } else {
+            $pointPosition = strlen($shortest);
+        }
+        $digits = $shortest;
+        $pointPosition += $exponent;
+
+        if ($pointPosition <= 0) {
+            $integerDigits = '0';
+            $fractionDigits = str_repeat('0', -$pointPosition) . $digits;
+        } elseif ($pointPosition >= strlen($digits)) {
+            $integerDigits = $digits . str_repeat('0', $pointPosition - strlen($digits));
+            $fractionDigits = '';
+        } else {
+            $integerDigits = substr($digits, 0, $pointPosition);
+            $fractionDigits = substr($digits, $pointPosition);
+        }
+
+        // Round the fraction to seven places on the decimal digits, carrying into the
+        // integer part when the fraction overflows.
+        if (strlen($fractionDigits) > 7) {
+            $roundsUp = $fractionDigits[7] >= '5';
+            $fractionDigits = substr($fractionDigits, 0, 7);
+            if ($roundsUp) {
+                $combined = $integerDigits . $fractionDigits;
+                $index = strlen($combined) - 1;
+                $carry = true;
+                while ($carry && $index >= 0) {
+                    if ($combined[$index] === '9') {
+                        $combined[$index] = '0';
+                    } else {
+                        $combined[$index] = (string) ((int) $combined[$index] + 1);
+                        $carry = false;
+                    }
+                    $index--;
+                }
+                if ($carry) {
+                    $combined = '1' . $combined;
+                }
+                $fractionDigits = substr($combined, -7);
+                $integerDigits = substr($combined, 0, -7);
+            }
+        }
+
+        $fractionDigits = rtrim($fractionDigits, '0');
+        $body = $fractionDigits === '' ? $integerDigits : $integerDigits . '.' . $fractionDigits;
+
+        // A zero result carries no sign.
+        if (trim($body, '0.') === '') {
+            return '0';
+        }
+        return $sign . $body;
     }
 }

--- a/Soneso/StellarSDK/SEP/TransferServerService/TransferServerService.php
+++ b/Soneso/StellarSDK/SEP/TransferServerService/TransferServerService.php
@@ -14,6 +14,7 @@ use GuzzleHttp\HandlerStack;
 use Psr\Http\Message\ResponseInterface;
 use Soneso\StellarSDK\Requests\RequestBuilder;
 use Soneso\StellarSDK\SEP\Toml\StellarToml;
+use Soneso\StellarSDK\SEP\Shared\SepRequestAmount;
 use Soneso\StellarSDK\Util\UrlValidator;
 
 /**
@@ -426,7 +427,7 @@ class TransferServerService
         $queryParameters = array();
         $queryParameters += ["operation" => $request->operation];
         $queryParameters += ["asset_code" => $request->assetCode];
-        $queryParameters += ["amount" => $request->amount];
+        $queryParameters += ["amount" => SepRequestAmount::format($request->amount)];
 
         if ($request->type) {
             $queryParameters += ["type" => $request->type];

--- a/Soneso/StellarSDK/SEP/TransferServerService/TransferServerService.php
+++ b/Soneso/StellarSDK/SEP/TransferServerService/TransferServerService.php
@@ -429,7 +429,7 @@ class TransferServerService
         $queryParameters += ["asset_code" => $request->assetCode];
         $queryParameters += ["amount" => SepRequestAmount::format($request->amount)];
 
-        if ($request->type) {
+        if ($request->type !== null) {
             $queryParameters += ["type" => $request->type];
         }
 

--- a/Soneso/StellarSDK/Soroban/Contract/AssembledTransaction.php
+++ b/Soneso/StellarSDK/Soroban/Contract/AssembledTransaction.php
@@ -360,8 +360,8 @@ class AssembledTransaction
 
         $shouldRestore = $restore ?? $this->options->methodOptions->restore;
         $this->simulationResult = null;
-        // Thread useUpgradedAuth from MethodOptions into the request; "useUpgradedAuth" appears in RPC params
-        // only when true. RPCs without Protocol 27 support silently ignore the flag.
+        // Thread useUpgradedAuth from MethodOptions into the request; the key is always sent with the
+        // current flag value. RPCs without Protocol 27 support silently ignore the flag.
         $this->simulationResponse = $this->server->simulateTransaction(new SimulateTransactionRequest(
             transaction: $this->tx,
             useUpgradedAuth: $this->options->methodOptions->useUpgradedAuth,

--- a/Soneso/StellarSDK/Soroban/Contract/MethodOptions.php
+++ b/Soneso/StellarSDK/Soroban/Contract/MethodOptions.php
@@ -37,17 +37,18 @@ class MethodOptions
      * @param bool $restore If true, will automatically attempt to restore archived ledger entries
      *                      that need renewal. Requires source account with private key. Default true.
      * @param bool $useUpgradedAuth When true, the simulate call requests ADDRESS_V2 credential entries
-     *                     (Protocol 27, CAP-71). The flag is forwarded to SimulateTransactionRequest
-     *                     and passed as "useUpgradedAuth": true in the RPC params only when enabled. RPCs
-     *                     without Protocol 27 support silently ignore it and return legacy ADDRESS
-     *                     entries. Do not enable on pre-27 networks. Default false.
+     *                     (Protocol 27, CAP-71); when false, legacy ADDRESS entries. The flag is
+     *                     forwarded to SimulateTransactionRequest. RPCs without Protocol 27 support
+     *                     silently ignore it and return legacy ADDRESS entries. Set to false on
+     *                     networks below Protocol 27, where ADDRESS_V2 entries invalidate the
+     *                     transaction. Default true.
      */
     public function __construct(
         public int $fee = StellarConstants::MIN_BASE_FEE_STROOPS,
         public int $timeoutInSeconds = NetworkConstants::DEFAULT_SOROBAN_TIMEOUT_SECONDS,
         public bool $simulate = true,
         public bool $restore = true,
-        public bool $useUpgradedAuth = false,
+        public bool $useUpgradedAuth = true,
     ) {
     }
 

--- a/Soneso/StellarSDK/Soroban/Contract/SorobanClient.php
+++ b/Soneso/StellarSDK/Soroban/Contract/SorobanClient.php
@@ -8,7 +8,6 @@ namespace Soneso\StellarSDK\Soroban\Contract;
 
 use Exception;
 use GuzzleHttp\Exception\GuzzleException;
-use Soneso\StellarSDK\CreateContractFromExternalRefHostFunction;
 use Soneso\StellarSDK\CreateContractFromExternalRefWithConstructorHostFunction;
 use Soneso\StellarSDK\CreateContractWithConstructorHostFunction;
 use Soneso\StellarSDK\Crypto\StrKey;
@@ -191,6 +190,11 @@ class SorobanClient
      * the transaction is built, so an unresolvable reference fails here instead of
      * on-chain.
      *
+     * The create operation uses the CREATE_CONTRACT_V2 host function form with the given
+     * constructor arguments (an empty vector when none are given), as deploy() does. For
+     * the plain CREATE_CONTRACT form, build the operation directly with
+     * CreateContractFromExternalRefHostFunction.
+     *
      * @param DeployFromExternalRefRequest $deployRequest Deployment parameters including the
      * executable owner, the tag, constructor args, and salt
      * @return SorobanClient The client for the newly deployed contract
@@ -228,21 +232,12 @@ class SorobanClient
         }
 
         $sourceAddress = Address::fromAccountId($deployRequest->sourceAccountKeyPair->getAccountId());
-        $constructorArgs = $deployRequest->constructorArgs ?? [];
-        if (count($constructorArgs) > 0) {
-            $createContractHostFunction = new CreateContractFromExternalRefWithConstructorHostFunction(
-                address: $sourceAddress,
-                executableOwner: $deployRequest->executableOwner,
-                tag: $deployRequest->tag,
-                constructorArgs: $constructorArgs,
-                salt: $deployRequest->salt);
-        } else {
-            $createContractHostFunction = new CreateContractFromExternalRefHostFunction(
-                address: $sourceAddress,
-                executableOwner: $deployRequest->executableOwner,
-                tag: $deployRequest->tag,
-                salt: $deployRequest->salt);
-        }
+        $createContractHostFunction = new CreateContractFromExternalRefWithConstructorHostFunction(
+            address: $sourceAddress,
+            executableOwner: $deployRequest->executableOwner,
+            tag: $deployRequest->tag,
+            constructorArgs: $deployRequest->constructorArgs ?? [],
+            salt: $deployRequest->salt);
 
         $builder = new InvokeHostFunctionOperationBuilder($createContractHostFunction);
         $op = $builder->build();

--- a/Soneso/StellarSDK/Soroban/Requests/SimulateTransactionRequest.php
+++ b/Soneso/StellarSDK/Soroban/Requests/SimulateTransactionRequest.php
@@ -11,16 +11,18 @@ use Soneso\StellarSDK\Transaction;
 /**
  * Soroban Simulate Transaction Request.
  *
- * The useUpgradedAuth flag requests that the RPC node return ADDRESS_V2 credential entries
- * (Protocol 27, CAP-71) instead of legacy ADDRESS entries during recording-mode simulation.
- * The flag is effective only in recording mode: when authMode is "record" or
- * "record_allow_nonroot", or when authMode is unset and the transaction carries no auth
- * entries (the RPC then defaults to recording). It is ignored under "enforce". RPCs without
- * Protocol 27 support silently ignore the flag and return legacy ADDRESS entries — support
- * is detected by inspecting the credential arm of returned entries, not by any error signal.
+ * The useUpgradedAuth flag selects the credential arm of auth entries recorded during
+ * simulation: true (the default) requests ADDRESS_V2 entries (Protocol 27, CAP-71), false
+ * requests legacy ADDRESS entries. The flag is effective only in recording mode: when
+ * authMode is "record" or "record_allow_nonroot", or when authMode is unset and the
+ * transaction carries no auth entries (the RPC then defaults to recording). It is ignored
+ * under "enforce". RPCs without Protocol 27 support silently ignore the flag and return
+ * legacy ADDRESS entries — support is detected by inspecting the credential arm of
+ * returned entries, not by any error signal.
  *
- * The key "useUpgradedAuth" is omitted from the request when the flag is false (the default), so
- * existing call sites require no changes and pre-27 RPCs never see the key.
+ * The key "useUpgradedAuth" is always present in the request params with the current flag
+ * value. Set the flag to false on a network below Protocol 27, where ADDRESS_V2 entries
+ * invalidate the transaction.
  *
  * @see https://developers.stellar.org/network/soroban-rpc/api-reference/methods/simulateTransaction
  * @package Soneso\StellarSDK\Soroban\Requests
@@ -37,23 +39,23 @@ class SimulateTransactionRequest
      *  transactions.
      * @param string|null $authMode Support for non-root authorization. Only available for protocol >= 23.
      *  Possible values: "enforce" | "record" | "record_allow_nonroot"
-     * @param bool $useUpgradedAuth When true, requests ADDRESS_V2 credential entries (Protocol 27, CAP-71).
-     *  The key is omitted when false; RPCs without support silently ignore it and return legacy entries.
-     *  Invalid on pre-27 networks: emitting ADDRESS_V2 entries on a pre-27 network invalidates the transaction.
+     * @param bool $useUpgradedAuth When true (the default), requests ADDRESS_V2 credential entries
+     *  (Protocol 27, CAP-71); when false, requests legacy ADDRESS entries. RPCs without support
+     *  silently ignore the flag and return legacy entries. Set to false on a network below
+     *  Protocol 27, where ADDRESS_V2 entries invalidate the transaction.
      */
     public function __construct(
         public Transaction $transaction,
         public ?ResourceConfig $resourceConfig = null,
         public ?string $authMode = null,
-        public bool $useUpgradedAuth = false,
+        public bool $useUpgradedAuth = true,
     ) {
     }
 
     /**
      * Builds and returns the request parameters array for the RPC API call.
      *
-     * The "useUpgradedAuth" key is included only when $useUpgradedAuth is true. Omitting the key (the default)
-     * preserves compatibility with pre-27 RPCs that do not recognize it.
+     * The "useUpgradedAuth" key is always included with the current flag value.
      *
      * @return array<string, mixed> The request parameters formatted for Soroban RPC
      */
@@ -68,9 +70,7 @@ class SimulateTransactionRequest
         if ($this->authMode !== null) {
             $params['authMode'] = $this->authMode;
         }
-        if ($this->useUpgradedAuth) {
-            $params['useUpgradedAuth'] = true;
-        }
+        $params['useUpgradedAuth'] = $this->useUpgradedAuth;
         return $params;
     }
 
@@ -148,8 +148,9 @@ class SimulateTransactionRequest
     /**
      * Sets the useUpgradedAuth flag.
      *
-     * When true, "useUpgradedAuth": true is included in the request params. RPCs without Protocol 27 support
-     * silently ignore the flag. Do not enable on pre-27 networks.
+     * When true, ADDRESS_V2 credential entries are requested during recording-mode simulation;
+     * when false, legacy ADDRESS entries. RPCs without Protocol 27 support silently ignore the
+     * flag. Set to false on networks below Protocol 27.
      *
      * @param bool $useUpgradedAuth whether to request ADDRESS_V2 credential entries
      */

--- a/Soneso/StellarSDK/Soroban/SorobanCredentials.php
+++ b/Soneso/StellarSDK/Soroban/SorobanCredentials.php
@@ -16,19 +16,21 @@ use Soneso\StellarSDK\Xdr\XdrSorobanCredentialsType;
  *
  * Represents one of four credential arms:
  * - SOURCE_ACCOUNT: uses the transaction source account; no address credentials.
- * - ADDRESS (legacy): address credentials without an address-bound preimage.
+ * - ADDRESS (legacy): address credentials without an address-bound preimage. Valid on
+ *   all protocol versions.
  * - ADDRESS_V2 (Protocol 27, CAP-71): address credentials with an address-bound preimage
- *   (ENVELOPE_TYPE_SOROBAN_AUTHORIZATION_WITH_ADDRESS). Opt-in; invalid on pre-27 networks.
+ *   (ENVELOPE_TYPE_SOROBAN_AUTHORIZATION_WITH_ADDRESS). Invalid on pre-27 networks.
  * - ADDRESS_WITH_DELEGATES (Protocol 27, CAP-71): ADDRESS_V2 with a recursive delegate
- *   tree. Opt-in; invalid on pre-27 networks.
+ *   tree. Invalid on pre-27 networks.
  *
  * The property $addressCredentials carries the inner SorobanAddressCredentials for the
  * ADDRESS and ADDRESS_V2 arms. For ADDRESS_WITH_DELEGATES, $addressWithDelegates carries
  * the full credentials-plus-delegates payload; $addressCredentials is null in that arm.
  *
- * Legacy behavior is preserved: the default arm is ADDRESS when address credentials are
- * set; existing callers that only use forSourceAccount() / forAddressCredentials() are
- * unaffected.
+ * The forAddress() and forAddressCredentials() factories build the ADDRESS_V2 arm;
+ * forAddressLegacy() and forAddressCredentialsLegacy() build the legacy ADDRESS arm.
+ * Passing a SorobanAddressCredentials object as the constructor's first argument also
+ * builds the legacy ADDRESS arm (single-argument calling convention).
  *
  * @package Soneso\StellarSDK\Soroban
  * @see SorobanAddressCredentials
@@ -97,10 +99,35 @@ class SorobanCredentials
     }
 
     /**
-     * Creates legacy ADDRESS credentials.
+     * Creates ADDRESS_V2 credentials (Protocol 27, CAP-71) for the given address.
      *
-     * Uses ENVELOPE_TYPE_SOROBAN_AUTHORIZATION (not address-bound). This is the default
-     * arm and is valid on all protocol versions.
+     * Uses ENVELOPE_TYPE_SOROBAN_AUTHORIZATION_WITH_ADDRESS (address-bound preimage).
+     * Invalid on networks below Protocol 27; use forAddressLegacy() there.
+     *
+     * @param Address $address the address to authorize
+     * @param int $nonce unique nonce for replay protection
+     * @param int $signatureExpirationLedger ledger after which the signature expires
+     * @param XdrSCVal $signature the signature data
+     * @return SorobanCredentials ADDRESS_V2 credentials
+     */
+    public static function forAddress(
+        Address $address,
+        int     $nonce,
+        int     $signatureExpirationLedger,
+        XdrSCVal $signature,
+    ): SorobanCredentials {
+        $addressCredentials = new SorobanAddressCredentials($address, $nonce, $signatureExpirationLedger, $signature);
+        return new SorobanCredentials(
+            XdrSorobanCredentialsType::SOROBAN_CREDENTIALS_ADDRESS_V2,
+            $addressCredentials,
+        );
+    }
+
+    /**
+     * Creates legacy ADDRESS credentials for the given address.
+     *
+     * Uses ENVELOPE_TYPE_SOROBAN_AUTHORIZATION (not address-bound). Valid on all
+     * protocol versions.
      *
      * @param Address $address the address to authorize
      * @param int $nonce unique nonce for replay protection
@@ -108,7 +135,7 @@ class SorobanCredentials
      * @param XdrSCVal $signature the signature data
      * @return SorobanCredentials legacy ADDRESS credentials
      */
-    public static function forAddress(
+    public static function forAddressLegacy(
         Address $address,
         int     $nonce,
         int     $signatureExpirationLedger,
@@ -122,12 +149,31 @@ class SorobanCredentials
     }
 
     /**
+     * Creates ADDRESS_V2 credentials (Protocol 27, CAP-71) from existing address credentials.
+     *
+     * Equivalent to forAddressCredentialsV2(). Invalid on networks below Protocol 27;
+     * use forAddressCredentialsLegacy() there.
+     *
+     * @param SorobanAddressCredentials $addressCredentials the address credentials
+     * @return SorobanCredentials ADDRESS_V2 credentials
+     */
+    public static function forAddressCredentials(SorobanAddressCredentials $addressCredentials): SorobanCredentials
+    {
+        return new SorobanCredentials(
+            XdrSorobanCredentialsType::SOROBAN_CREDENTIALS_ADDRESS_V2,
+            $addressCredentials,
+        );
+    }
+
+    /**
      * Creates legacy ADDRESS credentials from existing address credentials.
+     *
+     * Valid on all protocol versions.
      *
      * @param SorobanAddressCredentials $addressCredentials the address credentials
      * @return SorobanCredentials legacy ADDRESS credentials
      */
-    public static function forAddressCredentials(SorobanAddressCredentials $addressCredentials): SorobanCredentials
+    public static function forAddressCredentialsLegacy(SorobanAddressCredentials $addressCredentials): SorobanCredentials
     {
         return new SorobanCredentials(
             XdrSorobanCredentialsType::SOROBAN_CREDENTIALS_ADDRESS,
@@ -138,8 +184,8 @@ class SorobanCredentials
     /**
      * Creates ADDRESS_V2 credentials (Protocol 27, CAP-71).
      *
-     * Uses ENVELOPE_TYPE_SOROBAN_AUTHORIZATION_WITH_ADDRESS (address-bound preimage).
-     * Invalid on networks below Protocol 27.
+     * Equivalent to forAddressCredentials(). Uses ENVELOPE_TYPE_SOROBAN_AUTHORIZATION_WITH_ADDRESS
+     * (address-bound preimage). Invalid on networks below Protocol 27.
      *
      * @param SorobanAddressCredentials $addressCredentials the address credentials
      * @return SorobanCredentials ADDRESS_V2 credentials

--- a/Soneso/StellarSDK/Util/StellarAmount.php
+++ b/Soneso/StellarSDK/Util/StellarAmount.php
@@ -161,31 +161,79 @@ class StellarAmount
     /**
      * Creates a StellarAmount from a decimal string
      *
-     * Supports up to 7 decimal places. Commas and spaces are automatically removed.
+     * Surrounding whitespace and any space are removed, and a comma is rejected, because a comma
+     * separates groups in some locales and decimals in others. What remains must be digits with
+     * at most one decimal point and at most one leading sign. An asset carries seven decimal
+     * places, so a finer amount is rejected rather than rounded; trailing zeroes do not count
+     * towards that limit, and "0.50000000" is accepted as 0.5.
      *
      * @static
-     * @param string $decimalAmount The amount as a string (e.g., "100.5" or "1,000.25")
+     * @param string $decimalAmount The amount as a string (e.g., "100.5" or "1000.25")
      * @return StellarAmount The amount object
-     * @throws \InvalidArgumentException If amount exceeds maximum or is negative
+     * @throws \InvalidArgumentException If amount contains a comma, is not a decimal number,
+     *     carries more than seven decimal places, exceeds maximum or is negative
      */
     public static function fromString(string $decimalAmount) : StellarAmount {
-        $amountStr = str_replace(',', '', $decimalAmount);
-        $amountStr = str_replace(' ', '', $amountStr);
+        // A comma groups digits in some locales and separates decimals in others, so "100,5" names
+        // both 1005 and 100.5 and the intended one cannot be recovered from the string.
+        if (str_contains($decimalAmount, ',')) {
+            throw new \InvalidArgumentException(
+                'Amount must not contain a comma: ' . substr($decimalAmount, 0, 64));
+        }
+
+        // Surrounding whitespace is padding: an amount read from a file or a CSV cell carries a
+        // trailing newline. Whitespace between digits is not padding, so it is left in place for
+        // the check below to refuse rather than read as a group separator. A space is the one
+        // exception, removed anywhere, which is the long-standing contract of this method.
+        $amountStr = str_replace(' ', '', trim($decimalAmount, " \t\n\r\v\f"));
+
+        // The sign belongs to the amount as a whole, since the fractional digits are unsigned.
+        $negative = str_starts_with($amountStr, '-');
+        if ($negative || str_starts_with($amountStr, '+')) {
+            $amountStr = substr($amountStr, 1);
+        }
+
+        // What remains must be digits around at most one point. That refuses a second sign, which
+        // would otherwise be read as part of the integer and negated back to a positive amount,
+        // and it requires at least one digit, so an empty, sign-only or point-only string names no
+        // amount rather than zero. A zero amount itself stays valid, since a trustline limit of
+        // "0" removes the trustline. The pattern is deliberately ASCII: with the u modifier it
+        // would accept digits that carry no value here. The D modifier keeps $ from matching
+        // before a trailing newline.
+        if (preg_match('/^(\d+(\.\d*)?|\.\d+)$/D', $amountStr) !== 1) {
+            throw new \InvalidArgumentException(
+                'Amount is not a decimal number: ' . substr($decimalAmount, 0, 64));
+        }
+
         $parts = explode('.', $amountStr);
         $unscaledAmount = self::zero();
 
         // Everything to the left of the decimal point
-        if ($parts[0]) {
+        if ($parts[0] !== '') {
             $unscaledAmountLeft = (new BigInteger($parts[0]))->multiply(self::stroopScale());
             $unscaledAmount = $unscaledAmount->add($unscaledAmountLeft);
         }
 
         // Add everything to the right of the decimal point
-        if (count($parts) == 2 && str_replace('0', '', $parts[1]) != '') {
-            // Should be a total of 7 decimal digits to the right of the decimal
-            $unscaledAmountRight = str_pad($parts[1], 7, '0',STR_PAD_RIGHT);
-            $unscaledAmount = $unscaledAmount->add(new BigInteger($unscaledAmountRight));
+        if (count($parts) == 2) {
+            // Trailing zeroes carry no value, so an amount is only out of range once they are
+            // removed: "0.50000000" is 0.5 and fits, while "0.12345678" does not.
+            $fraction = rtrim($parts[1], '0');
+            if ($fraction !== '') {
+                if (strlen($fraction) > 7) {
+                    throw new \InvalidArgumentException(
+                        'Amount cannot have more than 7 decimal places: '
+                        . substr($decimalAmount, 0, 64));
+                }
+                $unscaledAmount = $unscaledAmount->add(
+                    new BigInteger(str_pad($fraction, 7, '0', STR_PAD_RIGHT)));
+            }
         }
+
+        if ($negative) {
+            $unscaledAmount = self::zero()->subtract($unscaledAmount);
+        }
+
         return new StellarAmount($unscaledAmount);
     }
     

--- a/Soneso/StellarSDK/Util/StellarAmount.php
+++ b/Soneso/StellarSDK/Util/StellarAmount.php
@@ -151,10 +151,18 @@ class StellarAmount
      * @static
      * @param float $amount The amount as a decimal number (e.g., 100.5 for 100.5 XLM)
      * @return StellarAmount The amount object
-     * @throws \InvalidArgumentException If amount exceeds maximum or is negative
+     * @throws \InvalidArgumentException If amount is not finite, exceeds maximum or is negative.
+     *     A negative amount smaller than half a stroop rounds to zero and is accepted.
      */
     public static function fromFloat(float $amount) : StellarAmount {
-        $amountStr = number_format($amount, 7, '.', '');
+        if (!is_finite($amount)) {
+            throw new \InvalidArgumentException('Amount must be a finite number');
+        }
+        // %F renders the float itself, giving the nearest stroop to the stored value. Scaling to
+        // stroops by a decimal pre-round instead can move the amount by a stroop or more, in
+        // either direction, once the scaled value leaves the range where that rounding can place
+        // a tie.
+        $amountStr = sprintf('%.7F', $amount);
         return self::fromString($amountStr);
     }
 

--- a/Soneso/StellarSDKTests/Unit/SEP/Interactive/InteractiveTest.php
+++ b/Soneso/StellarSDKTests/Unit/SEP/Interactive/InteractiveTest.php
@@ -189,6 +189,85 @@ class InteractiveTest extends TestCase
         $this->assertEquals(0.013, $response->getFee());
     }
 
+    public function testFeeAmountIsSentAsPlainDecimal(): void
+    {
+        $transferService = new InteractiveService($this->serviceAddress);
+        $mock = new MockHandler([
+            new Response(200, ['X-Foo' => 'Bar'], $this->requestFee()),
+            new Response(200, ['X-Foo' => 'Bar'], $this->requestFee()),
+        ]);
+
+        $capturedAmount = null;
+        $stack = new HandlerStack();
+        $stack->setHandler($mock);
+        $stack->push(Middleware::mapRequest(function (RequestInterface $request) use (&$capturedAmount) {
+            parse_str($request->getUri()->getQuery(), $query_array);
+            $capturedAmount = $query_array["amount"] ?? null;
+            return $request;
+        }));
+
+        $transferService->setMockHandlerStack($stack);
+
+        // 123 stroops. Casting the float spells it "1.23E-5".
+        $transferService->fee(new SEP24FeeRequest("deposit", "ETH", 0.0000123, null, $this->jwtToken));
+        $this->assertSame("0.0000123", $capturedAmount);
+
+        // Casting this float spells it "100000000", a different amount.
+        $transferService->fee(new SEP24FeeRequest("deposit", "ETH", 99999999.9999999, null, $this->jwtToken));
+        $this->assertSame("99999999.9999999", $capturedAmount);
+    }
+
+    public function testDepositAndWithdrawAmountsAreSentAsPlainDecimal(): void
+    {
+        $transferService = new InteractiveService($this->serviceAddress);
+        $mock = new MockHandler([
+            new Response(200, ['X-Foo' => 'Bar'], $this->requestInteractive()),
+            new Response(200, ['X-Foo' => 'Bar'], $this->requestInteractive()),
+        ]);
+
+        $capturedBody = null;
+        $stack = new HandlerStack();
+        $stack->setHandler($mock);
+        $stack->push(Middleware::mapRequest(function (RequestInterface $request) use (&$capturedBody) {
+            $capturedBody = $request->getBody()->__toString();
+            return $request;
+        }));
+
+        $transferService->setMockHandlerStack($stack);
+
+        // 123 stroops. Casting the float spells it "1.23E-5".
+        $depositRequest = new SEP24DepositRequest();
+        $depositRequest->jwt = $this->jwtToken;
+        $depositRequest->assetCode = "USD";
+        $depositRequest->amount = 0.0000123;
+        $transferService->deposit($depositRequest);
+        $this->assertNotNull($capturedBody);
+        $this->assertSame("0.0000123", $this->multipartField("amount", $capturedBody));
+
+        // Casting this float spells it "100000000", a different amount.
+        $withdrawRequest = new SEP24WithdrawRequest();
+        $withdrawRequest->jwt = $this->jwtToken;
+        $withdrawRequest->assetCode = "USD";
+        $withdrawRequest->amount = 99999999.9999999;
+        $transferService->withdraw($withdrawRequest);
+        $this->assertSame("99999999.9999999", $this->multipartField("amount", $capturedBody));
+    }
+
+    /**
+     * Returns the value of a named field in a multipart request body, or null when absent.
+     */
+    private function multipartField(string $name, ?string $body): ?string
+    {
+        if ($body === null) {
+            return null;
+        }
+        // Further part headers, Content-Length among them, may sit between the disposition line
+        // and the blank line that starts the value.
+        $pattern = '/name="' . preg_quote($name, '/') . '"\r\n(?:[^\r\n]+\r\n)*\r\n(.*?)\r\n/s';
+
+        return preg_match($pattern, $body, $matches) === 1 ? $matches[1] : null;
+    }
+
     public function testDepositSEP24(): void
     {
         $transferService = new InteractiveService($this->serviceAddress);

--- a/Soneso/StellarSDKTests/Unit/SEP/Interactive/InteractiveTest.php
+++ b/Soneso/StellarSDKTests/Unit/SEP/Interactive/InteractiveTest.php
@@ -195,6 +195,7 @@ class InteractiveTest extends TestCase
         $mock = new MockHandler([
             new Response(200, ['X-Foo' => 'Bar'], $this->requestFee()),
             new Response(200, ['X-Foo' => 'Bar'], $this->requestFee()),
+            new Response(200, ['X-Foo' => 'Bar'], $this->requestFee()),
         ]);
 
         $capturedAmount = null;
@@ -215,6 +216,11 @@ class InteractiveTest extends TestCase
         // Casting this float spells it "100000000", a different amount.
         $transferService->fee(new SEP24FeeRequest("deposit", "ETH", 99999999.9999999, null, $this->jwtToken));
         $this->assertSame("99999999.9999999", $capturedAmount);
+
+        // The stored float is 100000000000.100006103515625; the query must carry the
+        // shortest representation, not the binary expansion behind it.
+        $transferService->fee(new SEP24FeeRequest("deposit", "ETH", 100000000000.1, null, $this->jwtToken));
+        $this->assertSame("100000000000.1", $capturedAmount);
     }
 
     public function testDepositAndWithdrawAmountsAreSentAsPlainDecimal(): void

--- a/Soneso/StellarSDKTests/Unit/SEP/Shared/SepRequestAmountTest.php
+++ b/Soneso/StellarSDKTests/Unit/SEP/Shared/SepRequestAmountTest.php
@@ -1,0 +1,197 @@
+<?php declare(strict_types=1);
+
+// Copyright 2026 The Stellar PHP SDK Authors. All rights reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+namespace Soneso\StellarSDKTests\Unit\SEP\Shared;
+
+use PHPUnit\Framework\TestCase;
+use Soneso\StellarSDK\SEP\Shared\SepRequestAmount;
+
+class SepRequestAmountTest extends TestCase
+{
+    // Plain decimal rendering
+
+    public function testSmallAmountRendersPlainDecimal(): void
+    {
+        // 123 stroops, an ordinary amount. Casting the float spells it "1.23E-5".
+        $this->assertSame("0.0000123", SepRequestAmount::format(0.0000123));
+    }
+
+    public function testOneStroopRendersAllSevenDecimals(): void
+    {
+        $this->assertSame("0.0000001", SepRequestAmount::format(1e-7));
+    }
+
+    public function testWholeAmountSuppressesDecimalPoint(): void
+    {
+        $this->assertSame("100", SepRequestAmount::format(100.0));
+        $this->assertSame("1", SepRequestAmount::format(1.0));
+        // The trim stops at the decimal point, so zeroes in the integer part survive.
+        $this->assertSame("120", SepRequestAmount::format(120.0));
+        $this->assertSame("1000000000000000", SepRequestAmount::format(1e15));
+    }
+
+    public function testTrailingZeroesInFractionAreTrimmed(): void
+    {
+        $this->assertSame("0.000012", SepRequestAmount::format(0.0000120));
+        $this->assertSame("0.00001", SepRequestAmount::format(0.0000100));
+    }
+
+    public function testLargeAmountRendersPlainDecimal(): void
+    {
+        $this->assertSame("1000000000000000000000", SepRequestAmount::format(1e21));
+    }
+
+    // Significant digits the default precision setting drops
+
+    public function testSeventhDecimalSurvives(): void
+    {
+        // Casting these floats yields "12345678.123457" and "123456789.12346": the seventh
+        // decimal is lost because the precision setting caps significant digits at 14.
+        $this->assertSame("12345678.1234567", SepRequestAmount::format(12345678.1234567));
+        $this->assertSame("123456789.1234567", SepRequestAmount::format(123456789.1234567));
+    }
+
+    public function testAmountIsNotRoundedToADifferentAmount(): void
+    {
+        // Casting this float yields "100000000", a different amount.
+        $this->assertSame("99999999.9999999", SepRequestAmount::format(99999999.9999999));
+    }
+
+    public function testNoStroopIsInventedByADecimalPreScale(): void
+    {
+        // Formatting via a decimal pre-scale overstates these by a stroop: scaling by 10^7 pushes
+        // the value past the range where the pre-rounding can still place a tie, from 2^28 for
+        // fractional amounts and from ceil(2^52/1e7) for whole ones. 500000000.0 and 900000000.0
+        // are both carried exactly by the float.
+        $this->assertSame("500000000", SepRequestAmount::format(500000000.0));
+        $this->assertSame("900000000", SepRequestAmount::format(900000000.0));
+        $this->assertSame("780615714.9429096", SepRequestAmount::format(780615714.9429096));
+    }
+
+    public function testHalfStroopTieFollowsTheStoredFloat(): void
+    {
+        // The double nearest 1.5e-7 is 0.000000149999999999999993, so the nearer seven-decimal
+        // value is one stroop, not two.
+        $this->assertSame("0.0000001", SepRequestAmount::format(1.5e-7));
+    }
+
+    // Rounding to seven decimal places
+
+    public function testMoreThanSevenDecimalsRoundsToSeven(): void
+    {
+        $this->assertSame("1.2345679", SepRequestAmount::format(1.23456789));
+    }
+
+    public function testBelowHalfAStroopRoundsToZero(): void
+    {
+        $this->assertSame("0", SepRequestAmount::format(0.00000004));
+        $this->assertSame("0", SepRequestAmount::format(1e-10));
+    }
+
+    // Sign
+
+    public function testNegativeAmountKeepsItsSign(): void
+    {
+        $this->assertSame("-0.0000123", SepRequestAmount::format(-0.0000123));
+        $this->assertSame("-1000000000000000000000", SepRequestAmount::format(-1e21));
+    }
+
+    public function testZeroRendersWithoutSign(): void
+    {
+        $this->assertSame("0", SepRequestAmount::format(0.0));
+        $this->assertSame("0", SepRequestAmount::format(-0.0));
+        // An amount below half a stroop rounds away, and zero carries no sign.
+        $this->assertSame("0", SepRequestAmount::format(-1e-8));
+    }
+
+    // Non-finite amounts
+
+    public function testNonFiniteAmountRendersEmpty(): void
+    {
+        $this->assertSame("", SepRequestAmount::format(NAN));
+        $this->assertSame("", SepRequestAmount::format(INF));
+        $this->assertSame("", SepRequestAmount::format(-INF));
+    }
+
+    // Invariants
+
+    public function testNoFiniteAmountRendersAnExponent(): void
+    {
+        $amounts = [1e-7, 0.0000123, 1e-10, 1e15, 1e16, 1e21, -1e21, -0.0000123, PHP_FLOAT_MAX];
+        foreach ($amounts as $amount) {
+            $rendered = SepRequestAmount::format($amount);
+            $this->assertStringNotContainsStringIgnoringCase("e", $rendered, "exponent in " . $rendered);
+        }
+    }
+
+    /**
+     * Pins the output shape: digits, one optional period, an optional leading minus.
+     *
+     * This alone cannot tell a locale-independent rendering from a locale-following one. PHP starts
+     * every process at LC_NUMERIC "C" and never adopts the host's regional format, so %f and %F
+     * agree here; only a caller that has run setlocale() sees them diverge, which no test can
+     * observe without changing the process locale. testFormatterUsesTheLocaleIndependentConversion
+     * covers that separately.
+     */
+    public function testRenderingUsesAPeriodSeparator(): void
+    {
+        foreach ([0.0000123, 1e21, -0.0000123, 1e15, 1e-7, 500000000.0] as $amount) {
+            $rendered = SepRequestAmount::format($amount);
+            $this->assertSame(1, preg_match('/^-?[0-9]+(\.[0-9]+)?$/', $rendered),
+                "unexpected characters in " . $rendered);
+        }
+    }
+
+    /**
+     * The formatter must use the locale-independent %F conversion.
+     *
+     * A caller that has run setlocale(LC_NUMERIC, ...) with a comma-separated locale gets
+     * "0,0000123" from the lowercase %f and "0.0000123" from the uppercase %F, and an anchor
+     * parses neither the comma nor a value it never expected. The difference is invisible under
+     * the "C" locale every PHP process starts in, and the CI image installs no comma locale, so
+     * this is asserted against the source rather than skipped on hosts that cannot show it.
+     */
+    public function testFormatterUsesTheLocaleIndependentConversion(): void
+    {
+        // Comments are stripped first: a docblock naming either conversion would otherwise decide
+        // the outcome, letting a broken implementation pass because its comment mentions %F.
+        $file = (new \ReflectionClass(SepRequestAmount::class))->getFileName();
+        $code = '';
+        foreach (token_get_all((string) file_get_contents((string) $file)) as $token) {
+            if (is_array($token) && in_array($token[0], [T_COMMENT, T_DOC_COMMENT], true)) {
+                continue;
+            }
+            $code .= is_array($token) ? $token[1] : $token;
+        }
+
+        $this->assertStringContainsString("sprintf('%.7F', \$amount)", $code);
+        $this->assertDoesNotMatchRegularExpression('/%\.\d*f/', $code);
+    }
+
+    /**
+     * A caller that has run setlocale() must still get a period.
+     *
+     * The unconditional assertion runs everywhere, including a CI image that installs no comma
+     * locale. Where one is available the second assertion makes the check discriminating, because
+     * the lowercase %f then renders a comma while the formatter must not.
+     */
+    public function testRenderingSurvivesACommaLocale(): void
+    {
+        $previous = setlocale(LC_NUMERIC, '0');
+        $applied = setlocale(LC_NUMERIC, 'de_DE.UTF-8', 'de_DE', 'de_DE.utf8', 'fr_FR.UTF-8');
+
+        try {
+            $this->assertSame('0.0000123', SepRequestAmount::format(0.0000123));
+
+            if ($applied !== false && sprintf('%.1f', 0.5) === '0,5') {
+                $this->assertSame('0.0000123', SepRequestAmount::format(0.0000123));
+                $this->assertSame('500000000', SepRequestAmount::format(500000000.0));
+            }
+        } finally {
+            setlocale(LC_NUMERIC, $previous === false ? 'C' : $previous);
+        }
+    }
+}

--- a/Soneso/StellarSDKTests/Unit/SEP/Shared/SepRequestAmountTest.php
+++ b/Soneso/StellarSDKTests/Unit/SEP/Shared/SepRequestAmountTest.php
@@ -71,11 +71,45 @@ class SepRequestAmountTest extends TestCase
         $this->assertSame("780615714.9429096", SepRequestAmount::format(780615714.9429096));
     }
 
-    public function testHalfStroopTieFollowsTheStoredFloat(): void
+    public function testHalfwayFractionRoundsAwayFromZero(): void
     {
-        // The double nearest 1.5e-7 is 0.000000149999999999999993, so the nearer seven-decimal
-        // value is one stroop, not two.
-        $this->assertSame("0.0000001", SepRequestAmount::format(1.5e-7));
+        // The written value 0.00000015 ends exactly halfway at the seventh place.
+        $this->assertSame("0.0000002", SepRequestAmount::format(1.5e-7));
+        $this->assertSame("-0.0000002", SepRequestAmount::format(-1.5e-7));
+        // Half a stroop exactly is halfway at the zero boundary and rounds away,
+        // keeping its sign.
+        $this->assertSame("0.0000001", SepRequestAmount::format(5e-8));
+        $this->assertSame("-0.0000001", SepRequestAmount::format(-5e-8));
+    }
+
+    public function testLargeAmountKeepsTheWrittenDecimals(): void
+    {
+        // The stored float is 100000000000.100006103515625; the shortest representation is
+        // the written value, and no digit beyond it may be rendered.
+        $this->assertSame("100000000000.1", SepRequestAmount::format(100000000000.1));
+        $this->assertSame("-100000000000.1", SepRequestAmount::format(-100000000000.1));
+    }
+
+    public function testRoundingCarriesThroughTheIntegerPart(): void
+    {
+        $this->assertSame("1", SepRequestAmount::format(0.99999995));
+        $this->assertSame("2", SepRequestAmount::format(1.99999996));
+    }
+
+    public function testHostSerializePrecisionOverrideDoesNotChangeTheDigits(): void
+    {
+        // A host that caps or widens serialize_precision must neither change the rendering
+        // nor find its setting altered afterwards.
+        $previous = ini_set('serialize_precision', '17');
+        try {
+            $this->assertSame("0.1", SepRequestAmount::format(0.1));
+            $this->assertSame("100000000000.1", SepRequestAmount::format(100000000000.1));
+            $this->assertSame('17', ini_get('serialize_precision'));
+        } finally {
+            if ($previous !== false) {
+                ini_set('serialize_precision', $previous);
+            }
+        }
     }
 
     // Rounding to seven decimal places
@@ -133,7 +167,7 @@ class SepRequestAmountTest extends TestCase
      * This alone cannot tell a locale-independent rendering from a locale-following one. PHP starts
      * every process at LC_NUMERIC "C" and never adopts the host's regional format, so %f and %F
      * agree here; only a caller that has run setlocale() sees them diverge, which no test can
-     * observe without changing the process locale. testFormatterUsesTheLocaleIndependentConversion
+     * observe without changing the process locale. testFormatterUsesTheShortestRepresentation
      * covers that separately.
      */
     public function testRenderingUsesAPeriodSeparator(): void
@@ -146,18 +180,20 @@ class SepRequestAmountTest extends TestCase
     }
 
     /**
-     * The formatter must use the locale-independent %F conversion.
+     * The formatter must not use a printf float conversion.
      *
      * A caller that has run setlocale(LC_NUMERIC, ...) with a comma-separated locale gets
-     * "0,0000123" from the lowercase %f and "0.0000123" from the uppercase %F, and an anchor
-     * parses neither the comma nor a value it never expected. The difference is invisible under
-     * the "C" locale every PHP process starts in, and the CI image installs no comma locale, so
-     * this is asserted against the source rather than skipped on hosts that cannot show it.
+     * "0,0000123" from the lowercase %f, and any fixed-point conversion renders the binary
+     * expansion of the float rather than its shortest representation. The rendering is decimal
+     * string arithmetic on json_encode's output with serialize_precision pinned to -1, and the
+     * difference is invisible under the "C" locale every PHP process starts in and the default
+     * ini of the CI image, so this is asserted against the source rather than skipped on hosts
+     * that cannot show it.
      */
-    public function testFormatterUsesTheLocaleIndependentConversion(): void
+    public function testFormatterUsesTheShortestRepresentation(): void
     {
-        // Comments are stripped first: a docblock naming either conversion would otherwise decide
-        // the outcome, letting a broken implementation pass because its comment mentions %F.
+        // Comments are stripped first: a docblock naming a conversion would otherwise decide
+        // the outcome, letting a broken implementation pass because its comment mentions one.
         $file = (new \ReflectionClass(SepRequestAmount::class))->getFileName();
         $code = '';
         foreach (token_get_all((string) file_get_contents((string) $file)) as $token) {
@@ -167,8 +203,8 @@ class SepRequestAmountTest extends TestCase
             $code .= is_array($token) ? $token[1] : $token;
         }
 
-        $this->assertStringContainsString("sprintf('%.7F', \$amount)", $code);
-        $this->assertDoesNotMatchRegularExpression('/%\.\d*f/', $code);
+        $this->assertDoesNotMatchRegularExpression('/%[-+0 ]?\d*(\.\d+)?[fFgGeE]/', $code);
+        $this->assertStringContainsString("ini_set('serialize_precision', '-1')", $code);
     }
 
     /**

--- a/Soneso/StellarSDKTests/Unit/SEP/TransferServerService/TransferServerServiceTest.php
+++ b/Soneso/StellarSDKTests/Unit/SEP/TransferServerService/TransferServerServiceTest.php
@@ -220,6 +220,36 @@ class TransferServerServiceTest extends TestCase
         $this->assertEquals(0.013, $response->fee);
     }
 
+    public function testFeeAmountIsSentAsPlainDecimal(): void
+    {
+        $transferService = new TransferServerService($this->serviceAddress);
+        $mock = new MockHandler([
+            new Response(200, ['X-Foo' => 'Bar'], $this->requestFee()),
+            new Response(200, ['X-Foo' => 'Bar'], $this->requestFee()),
+        ]);
+
+        $capturedAmount = null;
+        $stack = new HandlerStack();
+        $stack->setHandler($mock);
+        $stack->push(Middleware::mapRequest(function (RequestInterface $request) use (&$capturedAmount) {
+            parse_str($request->getUri()->getQuery(), $query_array);
+            $capturedAmount = $query_array["amount"] ?? null;
+            return $request;
+        }));
+
+        $transferService->setMockHandlerStack($stack);
+
+        // 123 stroops. Casting the float spells it "1.23E-5".
+        $transferService->fee(new FeeRequest(
+            operation: "deposit", assetCode: "ETH", amount: 0.0000123, jwt: $this->jwtToken));
+        $this->assertSame("0.0000123", $capturedAmount);
+
+        // Casting this float spells it "100000000", a different amount.
+        $transferService->fee(new FeeRequest(
+            operation: "deposit", assetCode: "ETH", amount: 99999999.9999999, jwt: $this->jwtToken));
+        $this->assertSame("99999999.9999999", $capturedAmount);
+    }
+
     public function testDepositBankPayment(): void
     {
         $transferService = new TransferServerService($this->serviceAddress);

--- a/Soneso/StellarSDKTests/Unit/SEP/TransferServerService/TransferServerServiceTest.php
+++ b/Soneso/StellarSDKTests/Unit/SEP/TransferServerService/TransferServerServiceTest.php
@@ -226,6 +226,7 @@ class TransferServerServiceTest extends TestCase
         $mock = new MockHandler([
             new Response(200, ['X-Foo' => 'Bar'], $this->requestFee()),
             new Response(200, ['X-Foo' => 'Bar'], $this->requestFee()),
+            new Response(200, ['X-Foo' => 'Bar'], $this->requestFee()),
         ]);
 
         $capturedAmount = null;
@@ -248,6 +249,12 @@ class TransferServerServiceTest extends TestCase
         $transferService->fee(new FeeRequest(
             operation: "deposit", assetCode: "ETH", amount: 99999999.9999999, jwt: $this->jwtToken));
         $this->assertSame("99999999.9999999", $capturedAmount);
+
+        // The stored float is 100000000000.100006103515625; the query must carry the
+        // shortest representation, not the binary expansion behind it.
+        $transferService->fee(new FeeRequest(
+            operation: "deposit", assetCode: "ETH", amount: 100000000000.1, jwt: $this->jwtToken));
+        $this->assertSame("100000000000.1", $capturedAmount);
     }
 
     public function testFeeTypeZeroIsSent(): void

--- a/Soneso/StellarSDKTests/Unit/SEP/TransferServerService/TransferServerServiceTest.php
+++ b/Soneso/StellarSDKTests/Unit/SEP/TransferServerService/TransferServerServiceTest.php
@@ -250,6 +250,29 @@ class TransferServerServiceTest extends TestCase
         $this->assertSame("99999999.9999999", $capturedAmount);
     }
 
+    public function testFeeTypeZeroIsSent(): void
+    {
+        $transferService = new TransferServerService($this->serviceAddress);
+        $mock = new MockHandler([
+            new Response(200, ['X-Foo' => 'Bar'], $this->requestFee())
+        ]);
+
+        $capturedType = null;
+        $stack = new HandlerStack();
+        $stack->setHandler($mock);
+        $stack->push(Middleware::mapRequest(function (RequestInterface $request) use (&$capturedType) {
+            parse_str($request->getUri()->getQuery(), $query_array);
+            $capturedType = $query_array["type"] ?? null;
+            return $request;
+        }));
+
+        $transferService->setMockHandlerStack($stack);
+
+        $transferService->fee(new FeeRequest(
+            operation: "deposit", assetCode: "ETH", amount: 1.0, type: "0", jwt: $this->jwtToken));
+        $this->assertSame("0", $capturedType);
+    }
+
     public function testDepositBankPayment(): void
     {
         $transferService = new TransferServerService($this->serviceAddress);

--- a/Soneso/StellarSDKTests/Unit/SEP/WebAuthForContracts/P27WebAuthForContractsTest.php
+++ b/Soneso/StellarSDKTests/Unit/SEP/WebAuthForContracts/P27WebAuthForContractsTest.php
@@ -87,7 +87,7 @@ class P27WebAuthForContractsTest extends TestCase
     private function makeGoldenLegacyEntry(): SorobanAuthorizationEntry
     {
         $address = Address::fromAccountId(self::GOLDEN_ACCOUNT);
-        $creds   = SorobanCredentials::forAddress(
+        $creds   = SorobanCredentials::forAddressLegacy(
             $address,
             self::GOLDEN_NONCE,
             self::GOLDEN_EXPIRY,
@@ -131,7 +131,7 @@ class P27WebAuthForContractsTest extends TestCase
             XdrSorobanCredentialsType::SOROBAN_CREDENTIALS_ADDRESS_V2
                 => SorobanCredentials::forAddressCredentialsV2($addrCreds),
             default
-                => SorobanCredentials::forAddressCredentials($addrCreds),
+                => SorobanCredentials::forAddressCredentialsLegacy($addrCreds),
         };
 
         $contractAddress = Address::fromContractId(StrKey::decodeContractIdHex($contractId));

--- a/Soneso/StellarSDKTests/Unit/Soroban/AuthorizationTest.php
+++ b/Soneso/StellarSDKTests/Unit/Soroban/AuthorizationTest.php
@@ -238,7 +238,7 @@ class AuthorizationTest extends TestCase
         $xdr = $original->toXdr();
 
         $this->assertInstanceOf(XdrSorobanCredentials::class, $xdr);
-        $this->assertEquals(XdrSorobanCredentialsType::SOROBAN_CREDENTIALS_ADDRESS, $xdr->type->value);
+        $this->assertEquals(XdrSorobanCredentialsType::SOROBAN_CREDENTIALS_ADDRESS_V2, $xdr->type->value);
 
         $decoded = SorobanCredentials::fromXdr($xdr);
 

--- a/Soneso/StellarSDKTests/Unit/Soroban/HostFunctionTest.php
+++ b/Soneso/StellarSDKTests/Unit/Soroban/HostFunctionTest.php
@@ -28,6 +28,7 @@ use Soneso\StellarSDK\Xdr\XdrInvokeHostFunctionOp;
 use Soneso\StellarSDK\Xdr\XdrSCVal;
 use Soneso\StellarSDK\Xdr\XdrSCValType;
 use Exception;
+use InvalidArgumentException;
 
 /**
  * Unit tests for Soroban Host Function classes
@@ -598,6 +599,128 @@ class HostFunctionTest extends TestCase
 
         $this->assertSame($tag, $decoded->getTag());
         $this->assertEquals(base64_encode($original->toXdr()->encode()), base64_encode($decoded->toXdr()->encode()));
+    }
+
+    public function testCreateContractFromExternalRefRejectsNonContractOwner(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/only a contract can hold the executable tag entry/');
+
+        new CreateContractFromExternalRefHostFunction(
+            Address::fromAccountId(self::TEST_ACCOUNT_ID),
+            Address::fromAccountId(self::TEST_ISSUER_ID),
+            "token-v1",
+        );
+    }
+
+    public function testCreateContractFromExternalRefWithConstructorRejectsNonContractOwner(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/only a contract can hold the executable tag entry/');
+
+        new CreateContractFromExternalRefWithConstructorHostFunction(
+            Address::fromAccountId(self::TEST_ACCOUNT_ID),
+            Address::fromAccountId(self::TEST_ISSUER_ID),
+            "token-v1",
+            [XdrSCVal::forU32(7)],
+        );
+    }
+
+    public function testCreateContractFromExternalRefSetterRejectsNonContractOwner(): void
+    {
+        $hostFunction = new CreateContractFromExternalRefHostFunction(
+            Address::fromAccountId(self::TEST_ACCOUNT_ID),
+            Address::fromContractId(self::TEST_OWNER_ID_HEX),
+            "token-v1",
+        );
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/only a contract can hold the executable tag entry/');
+
+        $hostFunction->setExecutableOwner(Address::fromAccountId(self::TEST_ISSUER_ID));
+    }
+
+    public function testCreateContractFromExternalRefWithConstructorSetterRejectsNonContractOwner(): void
+    {
+        $hostFunction = new CreateContractFromExternalRefWithConstructorHostFunction(
+            Address::fromAccountId(self::TEST_ACCOUNT_ID),
+            Address::fromContractId(self::TEST_OWNER_ID_HEX),
+            "token-v1",
+            [],
+        );
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/only a contract can hold the executable tag entry/');
+
+        $hostFunction->setExecutableOwner(Address::fromAccountId(self::TEST_ISSUER_ID));
+    }
+
+    public function testCreateContractFromExternalRefToXdrRejectsDirectlyAssignedNonContractOwner(): void
+    {
+        $hostFunction = new CreateContractFromExternalRefHostFunction(
+            Address::fromAccountId(self::TEST_ACCOUNT_ID),
+            Address::fromContractId(self::TEST_OWNER_ID_HEX),
+            "token-v1",
+        );
+        // The public property bypasses the setter; toXdr() must still reject.
+        $hostFunction->executableOwner = Address::fromAccountId(self::TEST_ISSUER_ID);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/only a contract can hold the executable tag entry/');
+
+        $hostFunction->toXdr();
+    }
+
+    public function testCreateContractFromExternalRefWithConstructorToXdrRejectsDirectlyAssignedNonContractOwner(): void
+    {
+        $hostFunction = new CreateContractFromExternalRefWithConstructorHostFunction(
+            Address::fromAccountId(self::TEST_ACCOUNT_ID),
+            Address::fromContractId(self::TEST_OWNER_ID_HEX),
+            "token-v1",
+            [],
+        );
+        // The public property bypasses the setter; toXdr() must still reject.
+        $hostFunction->executableOwner = Address::fromAccountId(self::TEST_ISSUER_ID);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/only a contract can hold the executable tag entry/');
+
+        $hostFunction->toXdr();
+    }
+
+    public function testCreateContractFromExternalRefFromXdrRejectsNonContractOwner(): void
+    {
+        // The XDR layer serializes any owner address type; the wrapper refuses to carry one.
+        $xdr = XdrHostFunction::forCreatingContractWithExternalRef(
+            Address::fromAccountId(self::TEST_ACCOUNT_ID)->toXdr(),
+            Address::fromAccountId(self::TEST_ISSUER_ID)->toXdr(),
+            "token-v1",
+            str_repeat("\x11", 32),
+        );
+        $decodedXdr = XdrHostFunction::decode(new XdrBuffer($xdr->encode()));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/only a contract can hold the executable tag entry/');
+
+        CreateContractFromExternalRefHostFunction::fromXdr($decodedXdr);
+    }
+
+    public function testCreateContractFromExternalRefWithConstructorFromXdrRejectsNonContractOwner(): void
+    {
+        // The XDR layer serializes any owner address type; the wrapper refuses to carry one.
+        $xdr = XdrHostFunction::forCreatingContractV2WithExternalRef(
+            Address::fromAccountId(self::TEST_ACCOUNT_ID)->toXdr(),
+            Address::fromAccountId(self::TEST_ISSUER_ID)->toXdr(),
+            "token-v1",
+            str_repeat("\x11", 32),
+            [XdrSCVal::forU32(7)],
+        );
+        $decodedXdr = XdrHostFunction::decode(new XdrBuffer($xdr->encode()));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/only a contract can hold the executable tag entry/');
+
+        CreateContractFromExternalRefWithConstructorHostFunction::fromXdr($decodedXdr);
     }
 
     public function testFromXdrOperationParsesExternalRefCreate(): void

--- a/Soneso/StellarSDKTests/Unit/Soroban/P27AssembledTransactionTest.php
+++ b/Soneso/StellarSDKTests/Unit/Soroban/P27AssembledTransactionTest.php
@@ -84,36 +84,38 @@ class P27AssembledTransactionTest extends TestCase
     // =========================================================================
 
     /**
-     * The "useUpgradedAuth" key must be ABSENT from request params when $useUpgradedAuth is false (default).
+     * A default request must carry "useUpgradedAuth" as boolean true.
      */
-    public function testUseUpgradedAuthKeyAbsentByDefault(): void
+    public function testUseUpgradedAuthKeyPresentTrueByDefault(): void
     {
         $tx      = $this->buildMockTx();
         $request = new SimulateTransactionRequest(transaction: $tx);
 
         $params = $request->getRequestParams();
 
-        $this->assertArrayNotHasKey('useUpgradedAuth', $params, '"useUpgradedAuth" key must not appear when flag is false (default)');
+        $this->assertArrayHasKey('useUpgradedAuth', $params, '"useUpgradedAuth" key must appear by default');
+        $this->assertSame(true, $params['useUpgradedAuth'], '"useUpgradedAuth" must be boolean true by default (not a string or int)');
         $this->assertArrayHasKey('transaction', $params);
     }
 
     /**
-     * The "useUpgradedAuth" key must be ABSENT when explicitly set to false.
+     * The legacy opt-out must send "useUpgradedAuth" as boolean false.
      */
-    public function testUseUpgradedAuthKeyAbsentWhenExplicitFalse(): void
+    public function testUseUpgradedAuthKeyPresentFalseWhenOptedOut(): void
     {
         $tx      = $this->buildMockTx();
         $request = new SimulateTransactionRequest(transaction: $tx, useUpgradedAuth: false);
 
         $params = $request->getRequestParams();
 
-        $this->assertArrayNotHasKey('useUpgradedAuth', $params, '"useUpgradedAuth" key must not appear when explicitly false');
+        $this->assertArrayHasKey('useUpgradedAuth', $params, '"useUpgradedAuth" key must appear when explicitly false');
+        $this->assertSame(false, $params['useUpgradedAuth'], '"useUpgradedAuth" must be boolean false on opt-out (not a string or int)');
     }
 
     /**
-     * The "useUpgradedAuth" key must be present and equal to boolean true when opted in.
+     * The "useUpgradedAuth" key must be present and equal to boolean true when explicitly enabled.
      */
-    public function testUseUpgradedAuthKeyPresentAsBooleanTrueWhenOptedIn(): void
+    public function testUseUpgradedAuthKeyPresentAsBooleanTrueWhenExplicitTrue(): void
     {
         $tx      = $this->buildMockTx();
         $request = new SimulateTransactionRequest(transaction: $tx, useUpgradedAuth: true);
@@ -147,22 +149,22 @@ class P27AssembledTransactionTest extends TestCase
     }
 
     /**
-     * Setter/getter round-trip for useUpgradedAuth.
+     * Setter/getter round-trip for useUpgradedAuth. The wire key follows the flag value.
      */
     public function testUseUpgradedAuthSetterGetterRoundTrip(): void
     {
         $tx      = $this->buildMockTx();
         $request = new SimulateTransactionRequest(transaction: $tx);
 
-        $this->assertFalse($request->getUseUpgradedAuth());
-
-        $request->setUseUpgradedAuth(true);
         $this->assertTrue($request->getUseUpgradedAuth());
-        $this->assertArrayHasKey('useUpgradedAuth', $request->getRequestParams());
 
         $request->setUseUpgradedAuth(false);
         $this->assertFalse($request->getUseUpgradedAuth());
-        $this->assertArrayNotHasKey('useUpgradedAuth', $request->getRequestParams());
+        $this->assertSame(false, $request->getRequestParams()['useUpgradedAuth']);
+
+        $request->setUseUpgradedAuth(true);
+        $this->assertTrue($request->getUseUpgradedAuth());
+        $this->assertSame(true, $request->getRequestParams()['useUpgradedAuth']);
     }
 
     // =========================================================================
@@ -194,9 +196,9 @@ class P27AssembledTransactionTest extends TestCase
     }
 
     /**
-     * Mirror: default MethodOptions must NOT include "useUpgradedAuth" in the RPC request body.
+     * Default MethodOptions must send "useUpgradedAuth": true in the RPC request body.
      */
-    public function testMethodOptionsDefaultOmitsUseUpgradedAuthFromSimulateRequest(): void
+    public function testMethodOptionsDefaultSendsUseUpgradedAuthTrueInSimulateRequest(): void
     {
         $capturedBodies = [];
         $tx = $this->buildAssembledTransactionWithMock(
@@ -211,7 +213,30 @@ class P27AssembledTransactionTest extends TestCase
         $body = json_decode($capturedBodies[0], true);
         $this->assertIsArray($body);
         $params = $body['params'] ?? [];
-        $this->assertArrayNotHasKey('useUpgradedAuth', $params, '"useUpgradedAuth" must NOT appear in RPC params by default');
+        $this->assertArrayHasKey('useUpgradedAuth', $params, '"useUpgradedAuth" must appear in RPC params by default');
+        $this->assertSame(true, $params['useUpgradedAuth']);
+    }
+
+    /**
+     * The legacy opt-out on MethodOptions must send "useUpgradedAuth": false in the RPC request body.
+     */
+    public function testMethodOptionsUseUpgradedAuthFalseThreadsIntoSimulateRequest(): void
+    {
+        $capturedBodies = [];
+        $tx = $this->buildAssembledTransactionWithMock(
+            methodOptions: new MethodOptions(simulate: false, restore: false, useUpgradedAuth: false),
+            mockResponses: [$this->createSimulateResponse()],
+            capturedBodies: $capturedBodies,
+        );
+
+        $tx->simulate();
+
+        $this->assertCount(1, $capturedBodies, 'Expected exactly one RPC request');
+        $body = json_decode($capturedBodies[0], true);
+        $this->assertIsArray($body);
+        $params = $body['params'] ?? [];
+        $this->assertArrayHasKey('useUpgradedAuth', $params, '"useUpgradedAuth" must appear in RPC params when MethodOptions.useUpgradedAuth = false');
+        $this->assertSame(false, $params['useUpgradedAuth']);
     }
 
     // =========================================================================
@@ -270,7 +295,7 @@ class P27AssembledTransactionTest extends TestCase
         $signerKp     = KeyPair::random();
         $address      = Address::fromAccountId($signerKp->getAccountId());
         $addressCreds = new SorobanAddressCredentials($address, 1, 100, XdrSCVal::forVoid());
-        $creds        = SorobanCredentials::forAddressCredentials($addressCreds);
+        $creds        = SorobanCredentials::forAddressCredentialsLegacy($addressCreds);
         $entry        = new SorobanAuthorizationEntry($creds, $this->makeInvocation());
 
         $tx = $this->buildAssembledTransactionWithAuthEntries([$entry], $this->invokerKp);
@@ -494,14 +519,14 @@ class P27AssembledTransactionTest extends TestCase
         $address      = Address::fromAccountId($signerKp->getAccountId());
         $addressCreds = new SorobanAddressCredentials($address, 1, 100, XdrSCVal::forVoid());
         $validEntry   = new SorobanAuthorizationEntry(
-            SorobanCredentials::forAddressCredentials($addressCreds),
+            SorobanCredentials::forAddressCredentialsLegacy($addressCreds),
             $this->makeInvocation(),
         );
 
         // Unknown-arm entry: credentialType = 99, but a non-SOURCE_ACCOUNT type so it reaches
         // the unknown-arm check inside the loop.
         $addressCreds2 = new SorobanAddressCredentials($address, 2, 100, XdrSCVal::forVoid());
-        $badCreds      = SorobanCredentials::forAddressCredentials($addressCreds2);
+        $badCreds      = SorobanCredentials::forAddressCredentialsLegacy($addressCreds2);
         $badCreds->credentialType = 99;
         $badEntry = new SorobanAuthorizationEntry($badCreds, $this->makeInvocation());
 

--- a/Soneso/StellarSDKTests/Unit/Soroban/P27AuthorizationTest.php
+++ b/Soneso/StellarSDKTests/Unit/Soroban/P27AuthorizationTest.php
@@ -80,7 +80,7 @@ class P27AuthorizationTest extends TestCase
     private function makeGoldenLegacyEntry(): SorobanAuthorizationEntry
     {
         $address = Address::fromAccountId(self::GOLDEN_ACCOUNT);
-        $creds = SorobanCredentials::forAddress($address, self::GOLDEN_NONCE, self::GOLDEN_EXPIRY, XdrSCVal::forVoid());
+        $creds = SorobanCredentials::forAddressLegacy($address, self::GOLDEN_NONCE, self::GOLDEN_EXPIRY, XdrSCVal::forVoid());
         return new SorobanAuthorizationEntry($creds, $this->makeGoldenInvocation());
     }
 
@@ -115,7 +115,7 @@ class P27AuthorizationTest extends TestCase
     public function testRoundTripAddressLegacy(): void
     {
         $address  = Address::fromAccountId(self::GOLDEN_ACCOUNT);
-        $creds    = SorobanCredentials::forAddress($address, 42, 100, XdrSCVal::forVoid());
+        $creds    = SorobanCredentials::forAddressLegacy($address, 42, 100, XdrSCVal::forVoid());
         $xdr      = $creds->toXdr();
 
         $this->assertEquals(XdrSorobanCredentialsType::SOROBAN_CREDENTIALS_ADDRESS, $xdr->type->value);
@@ -144,6 +144,33 @@ class P27AuthorizationTest extends TestCase
         $this->assertNotNull($decoded->addressCredentials);
         $this->assertEquals(77, $decoded->addressCredentials->nonce);
         $this->assertEquals($xdr->encode(), $decoded->toXdr()->encode());
+    }
+
+    /**
+     * Factory arm selection: forAddress() and forAddressCredentials() build ADDRESS_V2;
+     * forAddressLegacy() and forAddressCredentialsLegacy() build legacy ADDRESS.
+     */
+    public function testFactoryArmSelection(): void
+    {
+        $address      = Address::fromAccountId(self::GOLDEN_ACCOUNT);
+        $addressCreds = new SorobanAddressCredentials($address, 1, 100, XdrSCVal::forVoid());
+
+        $this->assertEquals(
+            XdrSorobanCredentialsType::SOROBAN_CREDENTIALS_ADDRESS_V2,
+            SorobanCredentials::forAddress($address, 1, 100, XdrSCVal::forVoid())->credentialType,
+        );
+        $this->assertEquals(
+            XdrSorobanCredentialsType::SOROBAN_CREDENTIALS_ADDRESS_V2,
+            SorobanCredentials::forAddressCredentials($addressCreds)->credentialType,
+        );
+        $this->assertEquals(
+            XdrSorobanCredentialsType::SOROBAN_CREDENTIALS_ADDRESS,
+            SorobanCredentials::forAddressLegacy($address, 1, 100, XdrSCVal::forVoid())->credentialType,
+        );
+        $this->assertEquals(
+            XdrSorobanCredentialsType::SOROBAN_CREDENTIALS_ADDRESS,
+            SorobanCredentials::forAddressCredentialsLegacy($addressCreds)->credentialType,
+        );
     }
 
     public function testRoundTripAddressWithDelegates(): void
@@ -268,6 +295,21 @@ class P27AuthorizationTest extends TestCase
         $payload  = Hash::generate($preimage->encode());
 
         $this->assertEquals(self::GOLDEN_V2_PAYLOAD_HEX, bin2hex($payload));
+    }
+
+    /**
+     * An entry built with forAddress() carries ADDRESS_V2 credentials and hashes to the
+     * golden V2 payload, byte-identical to an entry built with forAddressCredentialsV2().
+     */
+    public function testForAddressEntryMatchesGoldenV2Vectors(): void
+    {
+        $address = Address::fromAccountId(self::GOLDEN_ACCOUNT);
+        $creds   = SorobanCredentials::forAddress($address, self::GOLDEN_NONCE, self::GOLDEN_EXPIRY, XdrSCVal::forVoid());
+        $entry   = new SorobanAuthorizationEntry($creds, $this->makeGoldenInvocation());
+
+        $preimage = $entry->buildPreimage(Network::testnet());
+        $this->assertEquals(self::GOLDEN_V2_PREIMAGE_B64, base64_encode($preimage->encode()));
+        $this->assertEquals(self::GOLDEN_V2_PAYLOAD_HEX, bin2hex(Hash::generate($preimage->encode())));
     }
 
     /**
@@ -405,7 +447,7 @@ class P27AuthorizationTest extends TestCase
 
         // Entry with expiry 0 initially; sign sets it to GOLDEN_EXPIRY.
         $address = Address::fromAccountId(self::GOLDEN_ACCOUNT);
-        $creds   = SorobanCredentials::forAddress($address, self::GOLDEN_NONCE, 0, XdrSCVal::forVoid());
+        $creds   = SorobanCredentials::forAddressLegacy($address, self::GOLDEN_NONCE, 0, XdrSCVal::forVoid());
         $entry   = new SorobanAuthorizationEntry($creds, $this->makeGoldenInvocation());
 
         $entry->sign($signer, Network::testnet(), self::GOLDEN_EXPIRY);

--- a/Soneso/StellarSDKTests/Unit/Soroban/P27CoverageClosureTest.php
+++ b/Soneso/StellarSDKTests/Unit/Soroban/P27CoverageClosureTest.php
@@ -194,7 +194,7 @@ class P27CoverageClosureTest extends TestCase
         $addressCreds = new SorobanAddressCredentials($address, 1, 100, XdrSCVal::forVoid());
 
         $this->assertFalse(SorobanCredentials::forSourceAccount()->isAddressBased());
-        $this->assertTrue(SorobanCredentials::forAddressCredentials($addressCreds)->isAddressBased());
+        $this->assertTrue(SorobanCredentials::forAddressCredentialsLegacy($addressCreds)->isAddressBased());
         $this->assertTrue(SorobanCredentials::forAddressCredentialsV2($addressCreds)->isAddressBased());
 
         $withDel = new SorobanAddressCredentialsWithDelegates($addressCreds, []);
@@ -593,15 +593,15 @@ class P27CoverageClosureTest extends TestCase
     // =========================================================================
 
     /**
-     * MethodOptions useUpgradedAuth property defaults to false and can be set via constructor.
+     * MethodOptions useUpgradedAuth property defaults to true and can be disabled via constructor.
      */
     public function testMethodOptionsUseUpgradedAuthPropertyDefault(): void
     {
         $default = new MethodOptions();
-        $this->assertFalse($default->useUpgradedAuth);
+        $this->assertTrue($default->useUpgradedAuth);
 
-        $enabled = new MethodOptions(useUpgradedAuth: true);
-        $this->assertTrue($enabled->useUpgradedAuth);
+        $legacy = new MethodOptions(useUpgradedAuth: false);
+        $this->assertFalse($legacy->useUpgradedAuth);
     }
 
     // =========================================================================
@@ -616,7 +616,7 @@ class P27CoverageClosureTest extends TestCase
         $topKp    = KeyPair::random();
         $address  = Address::fromAccountId($topKp->getAccountId());
         $addrCreds = new SorobanAddressCredentials($address, 1, 100, XdrSCVal::forVoid());
-        $creds     = SorobanCredentials::forAddressCredentials($addrCreds);
+        $creds     = SorobanCredentials::forAddressCredentialsLegacy($addrCreds);
         $entry     = new SorobanAuthorizationEntry($creds, $this->makeInvocation());
 
         $tx = $this->buildAssembledTransactionWithAuthEntries([$entry], KeyPair::fromSeed(self::TEST_SECRET));
@@ -726,7 +726,7 @@ class P27CoverageClosureTest extends TestCase
         $signerKp     = KeyPair::random();
         $address      = Address::fromAccountId($signerKp->getAccountId());
         $addressCreds = new SorobanAddressCredentials($address, 1, 100, XdrSCVal::forVec([XdrSCVal::forVoid()]));
-        $creds        = SorobanCredentials::forAddressCredentials($addressCreds);
+        $creds        = SorobanCredentials::forAddressCredentialsLegacy($addressCreds);
         $entry        = new SorobanAuthorizationEntry($creds, $this->makeInvocation());
 
         $tx = $this->buildAssembledTransactionWithAuthEntries([$entry], KeyPair::fromSeed(self::TEST_SECRET));
@@ -995,7 +995,7 @@ class P27CoverageClosureTest extends TestCase
         $address      = Address::fromAccountId($signerKp->getAccountId());
         $addressCreds = new SorobanAddressCredentials($address, 1, 100, XdrSCVal::forVoid());
         $validEntry   = new SorobanAuthorizationEntry(
-            SorobanCredentials::forAddressCredentials($addressCreds),
+            SorobanCredentials::forAddressCredentialsLegacy($addressCreds),
             $this->makeInvocation(),
         );
         $sourceEntry = new SorobanAuthorizationEntry(
@@ -1262,7 +1262,7 @@ class P27CoverageClosureTest extends TestCase
         $signerAddress  = Address::fromAccountId($signerKp->getAccountId());
         $signerCreds    = new SorobanAddressCredentials($signerAddress, 2, 100, XdrSCVal::forVoid());
         $signerEntry    = new SorobanAuthorizationEntry(
-            SorobanCredentials::forAddressCredentials($signerCreds),
+            SorobanCredentials::forAddressCredentialsLegacy($signerCreds),
             $this->makeInvocation(),
         );
 
@@ -1333,7 +1333,7 @@ class P27CoverageClosureTest extends TestCase
         $signerAddress = Address::fromAccountId($signerKp->getAccountId());
         $signerCreds   = new SorobanAddressCredentials($signerAddress, 2, 100, XdrSCVal::forVoid());
         $signerEntry   = new SorobanAuthorizationEntry(
-            SorobanCredentials::forAddressCredentials($signerCreds),
+            SorobanCredentials::forAddressCredentialsLegacy($signerCreds),
             $this->makeInvocation(),
         );
 

--- a/Soneso/StellarSDKTests/Unit/Soroban/SorobanClientTest.php
+++ b/Soneso/StellarSDKTests/Unit/Soroban/SorobanClientTest.php
@@ -19,7 +19,6 @@ use Psr\Log\NullLogger;
 use ReflectionClass;
 use ReflectionProperty;
 use Soneso\StellarSDK\AbstractTransaction;
-use Soneso\StellarSDK\CreateContractFromExternalRefHostFunction;
 use Soneso\StellarSDK\CreateContractFromExternalRefWithConstructorHostFunction;
 use Soneso\StellarSDK\Crypto\KeyPair;
 use Soneso\StellarSDK\HostFunction;
@@ -568,7 +567,7 @@ class SorobanClientTest extends TestCase
         $this->assertEquals(1, $hostFunction->getConstructorArgs()[0]->u32);
     }
 
-    public function testDeployFromExternalRefWithoutConstructorArgsUsesPlainHostFunction(): void
+    public function testDeployFromExternalRefWithoutConstructorArgsUsesV2WithEmptyVector(): void
     {
         $wasmHash = hash('sha256', 'test-wasm', true);
         $byteCode = $this->createContractByteCode('hello');
@@ -602,11 +601,51 @@ class SorobanClientTest extends TestCase
         $this->assertSame(0, $mock->count());
 
         $hostFunction = $this->capturedCreateHostFunction($history);
-        $this->assertInstanceOf(CreateContractFromExternalRefHostFunction::class, $hostFunction);
+        $this->assertInstanceOf(CreateContractFromExternalRefWithConstructorHostFunction::class, $hostFunction);
         $this->assertSame(self::TEST_ACCOUNT_ID, $hostFunction->getAddress()->accountId);
         $this->assertSame(self::TEST_OWNER_ID_HEX, $hostFunction->getExecutableOwner()->contractId);
         $this->assertSame(self::TEST_EXECUTABLE_TAG, $hostFunction->getTag());
         $this->assertSame(32, strlen($hostFunction->getSalt()));
+        $this->assertCount(0, $hostFunction->getConstructorArgs());
+    }
+
+    public function testDeployFromExternalRefWithEmptyConstructorArgsUsesV2WithEmptyVector(): void
+    {
+        $wasmHash = hash('sha256', 'test-wasm', true);
+        $byteCode = $this->createContractByteCode('hello');
+        $createdContract = Address::fromContractId(StrKey::decodeContractIdHex(self::TEST_CONTRACT_ID))->toXdrSCVal();
+
+        $mock = new MockHandler([
+            $this->ledgerEntryResponse($this->executableTagEntryData(
+                self::TEST_OWNER_ID_HEX, self::TEST_EXECUTABLE_TAG, XdrSCVal::forBytes($wasmHash))),
+            $this->ledgerEntryResponse($this->contractCodeEntryData($wasmHash, $byteCode)),
+            $this->accountEntryResponse(),
+            $this->simulateResponse(XdrSCVal::forVoid(), true),
+            $this->sendTransactionResponse(),
+            $this->getTransactionRpcResponse(GetTransactionResponse::STATUS_SUCCESS, $createdContract),
+        ]);
+        $history = [];
+        $server = $this->createMockedServer($mock, $history);
+        $keyPair = KeyPair::fromSeed(self::TEST_SECRET_SEED);
+
+        $deployRequest = new DeployFromExternalRefRequest(
+            rpcUrl: self::TEST_RPC_URL,
+            network: $this->testNetwork,
+            sourceAccountKeyPair: $keyPair,
+            executableOwner: Address::fromContractId(self::TEST_OWNER_ID_HEX),
+            tag: self::TEST_EXECUTABLE_TAG,
+            constructorArgs: [],
+            server: $server,
+        );
+
+        $client = SorobanClient::deployFromExternalRef($deployRequest);
+
+        $this->assertSame(self::TEST_CONTRACT_ID, $client->getContractId());
+        $this->assertSame(0, $mock->count());
+
+        $hostFunction = $this->capturedCreateHostFunction($history);
+        $this->assertInstanceOf(CreateContractFromExternalRefWithConstructorHostFunction::class, $hostFunction);
+        $this->assertCount(0, $hostFunction->getConstructorArgs());
     }
 
     public function testDeployFromExternalRefThrowsWhenTagEntryMissing(): void

--- a/Soneso/StellarSDKTests/Unit/Util/UtilTest.php
+++ b/Soneso/StellarSDKTests/Unit/Util/UtilTest.php
@@ -33,11 +33,21 @@ class UtilTest extends TestCase
         assertEquals("1005000000", $amount->getStroopsAsString());
     }
 
-    public function testStellarAmountFromStringWithCommas()
+    public function testStellarAmountFromStringRejectsCommas()
     {
-        $amount = StellarAmount::fromString("1,000.25");
-        assertEquals("1000.2500000", $amount->getDecimalValueAsString());
-        assertEquals("10002500000", $amount->getStroopsAsString());
+        // A comma groups digits in some locales and separates decimals in others, so "100,5" names
+        // both 1005 and 100.5 and the intended one cannot be recovered from the string.
+        foreach (["1,000.25", "100,5", "0,5"] as $amount) {
+            try {
+                StellarAmount::fromString($amount);
+                $this->fail("expected a comma to be rejected: " . $amount);
+            } catch (\InvalidArgumentException $e) {
+                $this->assertStringStartsWith("Amount must not contain a comma", $e->getMessage());
+            }
+        }
+
+        // A plain space stays accepted, matching the long-standing contract of this method.
+        assertEquals("10002500000", StellarAmount::fromString("1 000.25")->getStroopsAsString());
     }
 
     public function testStellarAmountFromStringWithSpaces()
@@ -95,6 +105,102 @@ class UtilTest extends TestCase
         $amount = StellarAmount::fromFloat(0.0);
         assertEquals("0.0000000", $amount->getDecimalValueAsString());
         assertEquals("0", $amount->getStroopsAsString());
+    }
+
+    public function testStellarAmountRejectsNegativeAmountsBelowOne()
+    {
+        // The sign of an amount whose integer part is zero lives nowhere else, so reading it off
+        // that part alone turns a negative amount into a payable positive one.
+        foreach ([-0.5, -0.0000123, -0.9999999] as $amount) {
+            try {
+                StellarAmount::fromFloat($amount);
+                $this->fail("expected a negative amount to be rejected: " . var_export($amount, true));
+            } catch (\InvalidArgumentException $e) {
+                assertEquals("Amount cannot be negative", $e->getMessage());
+            }
+        }
+
+        try {
+            StellarAmount::fromString("-0.5");
+            $this->fail("expected a negative amount string to be rejected");
+        } catch (\InvalidArgumentException $e) {
+            assertEquals("Amount cannot be negative", $e->getMessage());
+        }
+    }
+
+    public function testStellarAmountRejectsMalformedDecimalStrings()
+    {
+        // What follows the sign must be digits around at most one point. A second sign would
+        // otherwise be read as part of the integer and negated back, turning "--5" into a payable
+        // five, and a non-ASCII digit carries no value here.
+        foreach (["--5", "--5.0", "5-3", "++5", "+-5", "abc", "5e3", "1.2.3", "1..2",
+                     "\u{0665}\u{0660}\u{0660}", "\u{FF15}"] as $amount) {
+            try {
+                StellarAmount::fromString($amount);
+                $this->fail("expected a malformed amount to be rejected: " . $amount);
+            } catch (\InvalidArgumentException $e) {
+                $this->assertStringStartsWith("Amount is not a decimal number", $e->getMessage());
+            }
+        }
+
+        // Surrounding whitespace is padding and is removed.
+        assertEquals("5000000", StellarAmount::fromString("0.5\n")->getStroopsAsString());
+        assertEquals("1234000", StellarAmount::fromString("0.1234\n")->getStroopsAsString());
+        assertEquals("50000000", StellarAmount::fromString("\t5\r\n")->getStroopsAsString());
+
+        // Whitespace between digits is not padding, and joining the digits across it would name a
+        // different amount; only a plain space groups digits. A NUL is not whitespace at all, so a
+        // fixed-width or C-style buffer carrying one names no amount rather than the digits in it.
+        foreach (["1\x0B0", "1\x0C0", "1\n000.25", "1\t5", "100.5\x00", "\x005"] as $amount) {
+            try {
+                StellarAmount::fromString($amount);
+                $this->fail("expected the amount to be rejected: " . json_encode($amount));
+            } catch (\InvalidArgumentException $e) {
+                $this->assertStringStartsWith("Amount is not a decimal number", $e->getMessage());
+            }
+        }
+
+        // A single leading sign stays valid, and so do the shapes without one.
+        assertEquals("50000000", StellarAmount::fromString("+5")->getStroopsAsString());
+        assertEquals("5000000", StellarAmount::fromString(".5")->getStroopsAsString());
+        assertEquals("50000000", StellarAmount::fromString("5.")->getStroopsAsString());
+    }
+
+    public function testStellarAmountRejectsMoreThanSevenDecimalPlaces()
+    {
+        // An eighth significant decimal place names a value finer than a stroop, so it is rejected
+        // rather than rounded away.
+        foreach (["0.12345678", "1.23456789", "10.123456789", "0.00000005"] as $amount) {
+            try {
+                StellarAmount::fromString($amount);
+                $this->fail("expected more than seven decimal places to be rejected: " . $amount);
+            } catch (\InvalidArgumentException $e) {
+                $this->assertStringStartsWith("Amount cannot have more than 7 decimal places", $e->getMessage());
+            }
+        }
+
+        // Trailing zeroes carry no value and do not count towards the limit.
+        assertEquals("5000000", StellarAmount::fromString("0.50000000")->getStroopsAsString());
+        assertEquals("10000000", StellarAmount::fromString("1.0000000000")->getStroopsAsString());
+        assertEquals("1", StellarAmount::fromString("0.0000001")->getStroopsAsString());
+    }
+
+    public function testStellarAmountRejectsStringsNamingNoAmount()
+    {
+        // An empty, sign-only or point-only string names no amount, so it is refused rather than
+        // read as zero.
+        foreach (["", ".", "+", "-", "   ", "\n", "+.", "-."] as $amount) {
+            try {
+                StellarAmount::fromString($amount);
+                $this->fail("expected a string naming no amount to be rejected: " . json_encode($amount));
+            } catch (\InvalidArgumentException $e) {
+                $this->assertStringStartsWith("Amount is not a decimal number", $e->getMessage());
+            }
+        }
+
+        // A zero amount is a real amount: a trustline limit of "0" removes the trustline.
+        assertEquals("0", StellarAmount::fromString("0")->getStroopsAsString());
+        assertEquals("0", StellarAmount::fromString("0.0000000")->getStroopsAsString());
     }
 
     public function testStellarAmountFromFloatLargeNumber()

--- a/Soneso/StellarSDKTests/Unit/Util/UtilTest.php
+++ b/Soneso/StellarSDKTests/Unit/Util/UtilTest.php
@@ -203,6 +203,36 @@ class UtilTest extends TestCase
         assertEquals("0", StellarAmount::fromString("0.0000000")->getStroopsAsString());
     }
 
+    public function testStellarAmountRejectsNonFiniteFloats()
+    {
+        foreach ([NAN, INF, -INF] as $amount) {
+            try {
+                StellarAmount::fromFloat($amount);
+                $this->fail("expected a non-finite amount to be rejected");
+            } catch (\InvalidArgumentException $e) {
+                assertEquals("Amount must be a finite number", $e->getMessage());
+            }
+        }
+    }
+
+    public function testStellarAmountFromFloatRoundsTheStoredValue()
+    {
+        // The float nearest 1.5e-7 is 1.49999999999999993e-7, so one stroop is nearer than two.
+        assertEquals("1", StellarAmount::fromFloat(1.5e-7)->getStroopsAsString());
+    }
+
+    public function testStellarAmountFromFloatInventsNoStroop()
+    {
+        // On PHP 8.4 and later, scaling to stroops by a decimal pre-round adds a stroop to each of
+        // these; earlier versions round them correctly. The first three are carried exactly by the
+        // float; the fourth is 780615714.94290959835052490234375 and rounds to the stroop asserted
+        // here. The expected values are the correctly rounded ones on every version.
+        assertEquals("5000000000000000", StellarAmount::fromFloat(500000000.0)->getStroopsAsString());
+        assertEquals("9000000000000000", StellarAmount::fromFloat(900000000.0)->getStroopsAsString());
+        assertEquals("4503599630000000", StellarAmount::fromFloat(450359963.0)->getStroopsAsString());
+        assertEquals("7806157149429096", StellarAmount::fromFloat(780615714.9429096)->getStroopsAsString());
+    }
+
     public function testStellarAmountFromFloatLargeNumber()
     {
         // Note: Float precision issues may occur with very large numbers


### PR DESCRIPTION
This completes the remaining Protocol 28 items from #120 and carries five amount-handling fixes.

**Breaking: CAP-71 upgraded authorization is the default.** `SimulateTransactionRequest::$useUpgradedAuth` and `MethodOptions::$useUpgradedAuth` default to true, and the key is always sent, so an explicit false reaches the RPC as the legacy opt-out. `SorobanCredentials::forAddress()` and `forAddressCredentials()` build the `ADDRESS_V2` arm; the new `forAddressLegacy()` and `forAddressCredentialsLegacy()` factories build legacy `ADDRESS`. RPC servers without protocol 27 support silently ignore the flag and return legacy entries. Set the flag to false on a network below protocol 27, where `ADDRESS_V2` entries invalidate the transaction.

**CAP-85 deploy hardening.** `CreateContractFromExternalRefHostFunction` and `CreateContractFromExternalRefWithConstructorHostFunction` throw `InvalidArgumentException` for an executable owner that is not a contract address, in the constructor, the setter, and `toXdr()`; parsing an envelope into these classes applies the same check, while the raw XDR layer stays permissive. `SorobanClient::deployFromExternalRef()` always emits the `CREATE_CONTRACT_V2` form with the constructor arguments, as `deploy()` does; the plain `CREATE_CONTRACT` form stays available through the low-level builder.

**Amount handling.** The four float-typed anchor requests (SEP-6 fee and SEP-24 fee, deposit, and withdraw) render small and high-precision amounts correctly, from the shortest representation of the float, rounded to seven decimals with ties away from zero; a SEP-6 fee request `type` of "0" is sent instead of dropped. `StellarAmount::fromString` parses a leading plus correctly instead of zeroing the integer part and rejects amounts outside the documented decimal string format; a comma is now rejected, since it groups digits in some locales and separates decimals in others. `StellarAmount::fromFloat` renders with `%F` and throws for NaN and infinity, which previously became zero.
