### PR TITLE
Document XdrSCVal::toNative()

### DIFF
--- a/docs/soroban.md
+++ b/docs/soroban.md
@@ -1071,6 +1071,81 @@ foreach ($result->map as $entry) {
 }
 ```
 
+#### Converting to Native PHP Values
+
+`toNative()` recursively converts an `XdrSCVal` tree into native PHP values, so you don't have to walk `vec`/`map` entries or branch on `$result->type` by hand. It's opt-in — nothing in the SDK calls it for you, `invokeMethod()` and simulation responses still return `XdrSCVal` — and it never throws. When a value has no faithful native representation, `toNative()` returns that `XdrSCVal` (sub)value unchanged instead of raising an exception, so you can always check the result type before using it.
+
+Conversion outcomes by XDR type:
+
+| XDR type | Native result |
+|---|---|
+| Bool | `bool` |
+| Void | `null` |
+| U32, I32, I64 | `int` |
+| U64, Timepoint, Duration | `int`, or an unsigned decimal `string` when the value exceeds `PHP_INT_MAX` |
+| U128, I128, U256, I256 | `GMP` (same as `toBigInt()`) |
+| Bytes | `string` (raw binary) |
+| String, Symbol | `string` |
+| Vec | list `array`, elements converted recursively, order preserved |
+| Map | keyed `array` (rules below), or the `XdrSCVal` itself when the map can't convert |
+| Address | `Address` |
+| Error, Contract Instance, Ledger Key Contract Instance, Ledger Key Nonce, Executable Tag, and any other/future type | the `XdrSCVal` itself |
+
+Map keys follow narrower rules than values, since a PHP array key can only be `int` or `string`:
+
+- Symbol and String keys become `string`; U32, I32, I64 keys become `int`; U64/Timepoint/Duration follow the same int-or-decimal-string rule as values; U128/I128/U256/I256 keys become decimal `string`; Bytes keys become the raw binary `string`.
+- An address *key* converts to its StrKey string (`G...`/`C...`/...), not to an `Address` object — the opposite of an address *value*, which converts to `Address`. Objects can't be PHP array keys, so the key has to be the string form.
+- Any other key type (bool, vec, map, and so on) is unrepresentable, and PHP coerces canonical integer-decimal string keys to `int` (a symbol key `"123"` becomes the int key `123`).
+- The whole map falls back to the `XdrSCVal` itself, values left unconverted, when either a key is unrepresentable or two entries collide on the same PHP key after coercion (for example a symbol key `"1"` and a `U32` key `1`).
+
+```php
+<?php
+
+use Soneso\StellarSDK\Xdr\XdrSCMapEntry;
+use Soneso\StellarSDK\Xdr\XdrSCVal;
+
+// Build a value tree the way a contract result would arrive on the wire.
+$result = XdrSCVal::forMap([
+    new XdrSCMapEntry(XdrSCVal::forSymbol('name'), XdrSCVal::forString('Alice')),
+    new XdrSCMapEntry(XdrSCVal::forSymbol('balance'), XdrSCVal::forI128BigInt('1000000000000000000')),
+    new XdrSCMapEntry(XdrSCVal::forSymbol('tags'), XdrSCVal::forVec([
+        XdrSCVal::forSymbol('vip'),
+        XdrSCVal::forSymbol('verified'),
+    ])),
+]);
+
+$native = $result->toNative();
+
+echo $native['name'] . "\n";                // Alice
+echo gmp_strval($native['balance']) . "\n"; // 1000000000000000000
+echo implode(', ', $native['tags']) . "\n"; // vip, verified
+```
+
+Since a fallback returns the same `XdrSCVal` instance, check for it with `instanceof` before treating the result as a converted value:
+
+```php
+<?php
+
+use Soneso\StellarSDK\Xdr\XdrSCMapEntry;
+use Soneso\StellarSDK\Xdr\XdrSCVal;
+
+// A map with a bool key has no PHP array key equivalent, so the whole map
+// falls back to the XdrSCVal itself instead of a partially converted array.
+$mapWithBoolKey = XdrSCVal::forMap([
+    new XdrSCMapEntry(XdrSCVal::forBool(true), XdrSCVal::forU32(1)),
+]);
+
+$native = $mapWithBoolKey->toNative();
+
+if ($native instanceof XdrSCVal) {
+    // Fall back to manual inspection when toNative() can't represent the value.
+    foreach ($native->map ?? [] as $entry) {
+        echo $entry->key->b ? 'true' : 'false';
+        echo ' => ' . $entry->val->u32 . "\n";
+    }
+}
+```
+
 ## Events
 
 Query contract events emitted during execution. Useful for tracking transfers, state changes, and other contract activity.

--- a/skills/stellar-php-sdk/references/soroban_contracts.md
+++ b/skills/stellar-php-sdk/references/soroban_contracts.md
@@ -281,6 +281,137 @@ if ($txResponse->getStatus() === GetTransactionResponse::STATUS_SUCCESS) {
 }
 ```
 
+### Converting results to native PHP values
+
+`public function toNative(): mixed` on `XdrSCVal` recursively converts a value tree to
+native PHP values on a best-effort basis. It never throws: an arm with no faithful
+native representation returns that `XdrSCVal` (sub)value unchanged, same instance, not a
+copy.
+
+| XDR type | Native result |
+|---|---|
+| Bool | `bool` |
+| Void | `null` |
+| U32, I32, I64 | `int` |
+| U64, Timepoint, Duration | `int`, or an unsigned decimal `string` when the value exceeds `PHP_INT_MAX` |
+| U128, I128, U256, I256 | `GMP` (same as `toBigInt()`) |
+| Bytes | `string` (raw binary) |
+| String, Symbol | `string` |
+| Vec | list `array`, elements converted recursively, order preserved |
+| Map | keyed `array` (rules below), or the `XdrSCVal` itself when the map can't convert |
+| Address | `Address` |
+| Error, Contract Instance, Ledger Key Contract Instance, Ledger Key Nonce, Executable Tag, any other/future type | the `XdrSCVal` itself |
+
+Map key rules (PHP array keys can only be `int` or `string`):
+
+| Key arm | PHP array key |
+|---|---|
+| Symbol, String | `string` |
+| U32, I32, I64 | `int` |
+| U64, Timepoint, Duration | `int`, or unsigned decimal `string` per the uint64 rule |
+| U128, I128, U256, I256 | decimal `string` |
+| Bytes | the raw binary `string` |
+| Address | StrKey `string` (`G...`/`C...`/...) — not an `Address` object, unlike the value conversion |
+| any other arm, or a required key payload that is `null` | unrepresentable |
+
+The whole map falls back to the `XdrSCVal` itself (values left unconverted) when a key
+is unrepresentable, or when two entries collide on the same PHP key after coercion. A
+fallback of a nested map is contained: the enclosing vec/map still converts, with the
+problematic map left as an `XdrSCVal` element.
+
+```php
+<?php declare(strict_types=1);
+
+use Soneso\StellarSDK\Xdr\XdrSCMapEntry;
+use Soneso\StellarSDK\Xdr\XdrSCVal;
+
+XdrSCVal::forU32(4294967295)->toNative(); // int(4294967295)
+
+// uint64 above PHP_INT_MAX: the stored bit pattern wraps, so -1 means 2^64-1
+XdrSCVal::forU64(-1)->toNative(); // string(20) "18446744073709551615"
+
+// Map with symbol keys, insertion order preserved
+$val = XdrSCVal::forMap([
+    new XdrSCMapEntry(XdrSCVal::forSymbol('name'), XdrSCVal::forString('Alice')),
+    new XdrSCMapEntry(XdrSCVal::forSymbol('age'), XdrSCVal::forU32(30)),
+]);
+$val->toNative(); // ['name' => 'Alice', 'age' => 30]
+```
+
+**Trap: uint64 values above `PHP_INT_MAX` arrive as strings, not int.**
+
+```php
+<?php declare(strict_types=1);
+
+use Soneso\StellarSDK\Xdr\XdrSCVal;
+
+// WRONG: assumes toNative() always returns int for U64/Timepoint/Duration
+$seconds = XdrSCVal::forU64(-1)->toNative();
+$next = $seconds + 1; // silently loses precision: becomes a float, not an error
+
+// CORRECT: a uint64 whose true value exceeds PHP_INT_MAX comes back as a string
+$seconds = XdrSCVal::forU64(-1)->toNative();
+$next = is_int($seconds) ? $seconds + 1 : gmp_add($seconds, 1);
+```
+
+**Trap: detecting a map fallback with `instanceof XdrSCVal`.**
+
+```php
+<?php declare(strict_types=1);
+
+use Soneso\StellarSDK\Xdr\XdrSCMapEntry;
+use Soneso\StellarSDK\Xdr\XdrSCVal;
+
+$mapWithBoolKey = XdrSCVal::forMap([
+    new XdrSCMapEntry(XdrSCVal::forBool(true), XdrSCVal::forU32(1)),
+]);
+
+// WRONG: assumes toNative() on a map always returns an array
+$native = $mapWithBoolKey->toNative();
+foreach ($native as $key => $value) { // no exception: silently iterates the object's public properties (type, b, u32, ...) instead of map entries — wrong data, not a crash
+    // ...
+}
+
+// CORRECT: check for the fallback before treating the result as an array
+$native = $mapWithBoolKey->toNative();
+if ($native instanceof XdrSCVal) {
+    // Same instance as $mapWithBoolKey; inspect $native->map manually.
+    foreach ($native->map ?? [] as $entry) {
+        // $entry->key and $entry->val are XdrSCVal
+    }
+} else {
+    // $native is a keyed array
+}
+```
+
+**Trap: address value/key asymmetry — a map key never becomes an `Address` object.**
+
+```php
+<?php declare(strict_types=1);
+
+use Soneso\StellarSDK\Xdr\XdrSCAddress;
+use Soneso\StellarSDK\Xdr\XdrSCMapEntry;
+use Soneso\StellarSDK\Xdr\XdrSCVal;
+
+$accountId = 'GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H';
+$mapVal = XdrSCVal::forMap([
+    new XdrSCMapEntry(XdrSCVal::forAddress(XdrSCAddress::forAccountId($accountId)), XdrSCVal::forU32(1)),
+]);
+
+// WRONG: expects an Address object as the map key, like an address VALUE converts to
+$native = $mapVal->toNative();
+$key = array_key_first($native);
+$key->toStrKey(); // Error: $key is a string ('G...'), not an Address
+
+// CORRECT: an address used as a map key converts to its StrKey string directly
+$native = $mapVal->toNative();
+$key = array_key_first($native); // already 'GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H'
+
+// An address VALUE (not a key) still converts to an Address object:
+$addressValue = XdrSCVal::forAddress(XdrSCAddress::forAccountId($accountId))->toNative();
+$addressValue->toStrKey(); // works: $addressValue is an Address
+```
+
 ## Argument Encoding
 
 Build contract arguments using `XdrSCVal` factory methods.


### PR DESCRIPTION
Documents `XdrSCVal::toNative()`, added in #124, in the Soroban guide and the SDK skill reference.