### PR TITLE
Update XDR definitions to stellar-xdr c40231c

### DIFF
--- a/.github/workflows/xdr-update-check.yml
+++ b/.github/workflows/xdr-update-check.yml
@@ -179,9 +179,10 @@ jobs:
           printf '%s\n' \
             '1. Update `XDR_COMMIT` in the repo-root `Makefile` to the upstream commit shown above' \
             '2. Run `make xdr-update` to re-download `.x` files and regenerate the PHP XDR types' \
-            '3. Run `composer test` and fix any test failures' \
-            '4. If the XDR changes introduce new types or extend existing ones (e.g. new operations, transaction fields, or protocol features), evaluate whether the SDK needs new or updated high-level APIs to support them (e.g. operation builders, TxRep, SEP implementations)' \
-            '5. Update the changelog and release notes with any breaking changes or new features' >> /tmp/issue_body.md
+            '3. Run `make xdr-generator-test` and `make xdr-validate`; if the snapshot diffs show only the intended upstream change, run `make xdr-generator-update-snapshots` and re-run the test' \
+            '4. Run `composer test` and fix any test failures' \
+            '5. If the XDR changes introduce new types or extend existing ones (e.g. new operations, transaction fields, or protocol features), evaluate whether the SDK needs new or updated high-level APIs to support them (e.g. operation builders, TxRep, SEP implementations)' \
+            '6. Update the changelog and release notes with any breaking changes or new features' >> /tmp/issue_body.md
           printf '\nSee the [XDR generator README](tools/xdr-generator/README.md) for detailed instructions.\n' >> /tmp/issue_body.md
           printf '\n---\n*This issue was created automatically by the [XDR update check workflow](.github/workflows/xdr-update-check.yml).*\n' >> /tmp/issue_body.md
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-XDR_COMMIT = 911c9356277468cb588481bd90b5d4b6eda395a7
+XDR_COMMIT = c40231c76bf2ebce76b24aa11c72508ac3eaa329
 XDRS = Stellar-SCP.x Stellar-ledger-entries.x Stellar-ledger.x \
        Stellar-overlay.x Stellar-transaction.x Stellar-types.x \
        Stellar-contract.x Stellar-contract-spec.x \

--- a/Soneso/StellarSDK/Xdr/XdrSCSpecEventV0.php
+++ b/Soneso/StellarSDK/Xdr/XdrSCSpecEventV0.php
@@ -131,7 +131,10 @@ class XdrSCSpecEventV0 {
                 'Missing required field name for XdrSCSpecEventV0'
             );
         }
-        $name = (static function ($v) { if (!is_string($v)) { throw new InvalidArgumentException('Expected string JSON value, got ' . get_debug_type($v)); } return XdrJsonHelper::unescapeString($v); })($value['name']);
+        if (!is_string($value['name'])) {
+            throw new InvalidArgumentException('Expected string JSON value, got ' . get_debug_type($value['name']));
+        }
+        $name = XdrJsonHelper::unescapeString($value['name']);
         if (!array_key_exists('prefix_topics', $value)) {
             throw new InvalidArgumentException(
                 'Missing required field prefix_topics for XdrSCSpecEventV0'

--- a/xdr/Stellar-contract-spec.x
+++ b/xdr/Stellar-contract-spec.x
@@ -12,6 +12,8 @@ namespace stellar
 
 const SC_SPEC_DOC_LIMIT = 1024;
 
+const SC_SPEC_TYPE_NAME_LIMIT = 1024;
+
 enum SCSpecType
 {
     SC_SPEC_TYPE_VAL = 0,
@@ -82,7 +84,7 @@ struct SCSpecTypeBytesN
 
 struct SCSpecTypeUDT
 {
-    string name<60>;
+    string name<SC_SPEC_TYPE_NAME_LIMIT>;
 };
 
 union SCSpecTypeDef switch (SCSpecType type)
@@ -134,7 +136,7 @@ struct SCSpecUDTStructV0
 {
     string doc<SC_SPEC_DOC_LIMIT>;
     string lib<80>;
-    string name<60>;
+    string name<SC_SPEC_TYPE_NAME_LIMIT>;
     SCSpecUDTStructFieldV0 fields<>;
 };
 
@@ -169,7 +171,7 @@ struct SCSpecUDTUnionV0
 {
     string doc<SC_SPEC_DOC_LIMIT>;
     string lib<80>;
-    string name<60>;
+    string name<SC_SPEC_TYPE_NAME_LIMIT>;
     SCSpecUDTUnionCaseV0 cases<>;
 };
 
@@ -184,7 +186,7 @@ struct SCSpecUDTEnumV0
 {
     string doc<SC_SPEC_DOC_LIMIT>;
     string lib<80>;
-    string name<60>;
+    string name<SC_SPEC_TYPE_NAME_LIMIT>;
     SCSpecUDTEnumCaseV0 cases<>;
 };
 
@@ -199,7 +201,7 @@ struct SCSpecUDTErrorEnumV0
 {
     string doc<SC_SPEC_DOC_LIMIT>;
     string lib<80>;
-    string name<60>;
+    string name<SC_SPEC_TYPE_NAME_LIMIT>;
     SCSpecUDTErrorEnumCaseV0 cases<>;
 };
 
@@ -243,7 +245,7 @@ struct SCSpecEventV0
 {
     string doc<SC_SPEC_DOC_LIMIT>;
     string lib<80>;
-    SCSymbol name;
+    string name<SC_SPEC_TYPE_NAME_LIMIT>;
     SCSymbol prefixTopics<2>;
     SCSpecEventParamV0 params<>;
     SCSpecEventDataFormat dataFormat;


### PR DESCRIPTION
Updates the vendored XDR to stellar/stellar-xdr commit c40231c. The contract spec name limit is raised to 1024 bytes via the new SC_SPEC_TYPE_NAME_LIMIT constant, and SCSpecEventV0.name is a plain string instead of an SCSymbol. Binary encoding is unchanged.

Closes #128